### PR TITLE
Add grimoire rendering predicates and fix Drunk impairment

### DIFF
--- a/botc.lp
+++ b/botc.lp
@@ -463,3 +463,24 @@ died(P, day(N, exec)) :- executed(P, N).
 
 % Validate: executed player must have been alive at start of day
 :- executed(P, N), not alive(P, day(N, 0)).
+
+% ===========================================================================
+% Grimoire State (for rendering)
+% These predicates provide a clean interface for a frontend to render the
+% grimoire at any point in time with minimal deduction.
+% ===========================================================================
+
+% grimoire_token(Player, RoleToken, Time) - what role token to display for a player
+% This is the token they received (what they think they are), not their true role.
+% A Drunk with the Chef token should display as Chef.
+grimoire_token(P, R, T) :- received(P, R), time(T).
+
+% grimoire_reminder(Player, ReminderToken, Time) - which reminder tokens to show
+grimoire_reminder(P, Token, T) :- reminder_on(Token, P, T).
+
+% grimoire_alive(Player, Time) - whether the player is alive
+grimoire_alive(P, T) :- alive(P, T).
+
+% grimoire_true_role(Player, Role) - the player's actual role (ST view only)
+% This is for the ST's knowledge, not displayed on tokens.
+grimoire_true_role(P, R) :- assigned(0, P, R).

--- a/tb.lp
+++ b/tb.lp
@@ -2,6 +2,10 @@
 never_in_bag(drunk).
 mistaken_identity(drunk, townsfolk).
 
+% Drunk is always impaired - place "Is the Drunk" reminder token
+reminder_on(drunk_is_drunk, P, T) :- assigned(0, P, drunk), time(T), alive(P, T).
+causes_impairment(drunk_is_drunk).
+
 townsfolk(X) :- tb_townsfolk(X).
 outsider(X) :- tb_outsider(X).
 minion(X) :- tb_minion(X).
@@ -761,4 +765,38 @@ sw_becomes_demon(SW, N) :-
 
 % When Scarlet Woman becomes demon, she gains the Imp role
 assigned(N, SW, imp) :- sw_becomes_demon(SW, N).
+
+% ===========================================================================
+% Reminder Token Metadata (for grimoire rendering)
+% ===========================================================================
+
+% reminder_belongs_to(Token, Role) - which role owns this reminder token
+reminder_belongs_to(drunk_is_drunk, drunk).
+reminder_belongs_to(poi_poisoned, poisoner).
+reminder_belongs_to(ww_townsfolk, washerwoman).
+reminder_belongs_to(ww_wrong, washerwoman).
+reminder_belongs_to(lib_outsider, librarian).
+reminder_belongs_to(lib_wrong, librarian).
+reminder_belongs_to(inv_minion, investigator).
+reminder_belongs_to(inv_wrong, investigator).
+reminder_belongs_to(ft_red_herring, fortune_teller).
+reminder_belongs_to(but_master, butler).
+reminder_belongs_to(sla_no_ability, slayer).
+reminder_belongs_to(monk_protected, monk).
+reminder_belongs_to(imp_dead, imp).
+
+% reminder_label(Token, Label) - human-readable label for grimoire display
+reminder_label(drunk_is_drunk, "Is the Drunk").
+reminder_label(poi_poisoned, "Poisoned").
+reminder_label(ww_townsfolk, "Townsfolk").
+reminder_label(ww_wrong, "Wrong").
+reminder_label(lib_outsider, "Outsider").
+reminder_label(lib_wrong, "Wrong").
+reminder_label(inv_minion, "Minion").
+reminder_label(inv_wrong, "Wrong").
+reminder_label(ft_red_herring, "Red herring").
+reminder_label(but_master, "Master").
+reminder_label(sla_no_ability, "No ability").
+reminder_label(monk_protected, "Protected").
+reminder_label(imp_dead, "Dead").
 


### PR DESCRIPTION
## Summary
Add predicates to support frontend grimoire rendering and fix a bug where Drunk was never impaired.

## Changes

### Grimoire rendering predicates (botc.lp)
- `grimoire_token/3`: displays received token (what player thinks they are)
- `grimoire_reminder/3`: reminder tokens on a player at a time
- `grimoire_alive/2`: alive status at a time
- `grimoire_true_role/2`: actual role (ST view only)

### Drunk impairment fix (tb.lp)
- Add `drunk_is_drunk` reminder token placed on Drunk players while alive
- This token causes impairment (previously Drunk was never impaired!)

### Reminder token metadata (tb.lp)
- `reminder_belongs_to/2`: maps token to owning role
- `reminder_label/2`: human-readable labels for display

## Test plan
- [x] All 42 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)