### PR TITLE
Remove predicate modal popup on timeline click, keep scroll-to-atom feature

### DIFF
--- a/web-ui/src/Component/ClingoDemo.purs
+++ b/web-ui/src/Component/ClingoDemo.purs
@@ -284,7 +284,7 @@ renderResult state = case state.result of
                   ]
               , HH.p
                   [ HP.style "font-size: 12px; color: #666; margin-bottom: 10px; font-style: italic;" ]
-                  [ HH.text "Click on timeline events to navigate to the atom in the answer set and its rule definition." ]
+                  [ HH.text "Click on timeline events to highlight the corresponding atom in the answer set below." ]
               , HH.slot _timelineGrimoire unit TG.component atoms HandleTimelineEvent
               ]
           Nothing -> HH.text ""
@@ -569,17 +569,13 @@ handleAction = case _ of
       Nothing -> pure unit
 
   HandleTimelineEvent output -> case output of
-    TG.TimelineEventClicked { sourceAtom, predicateName, predicateArity } -> do
-      -- First, scroll to the atom in the answer set display
+    TG.TimelineEventClicked { sourceAtom } -> do
+      -- Scroll to the atom in the answer set display
       if sourceAtom /= ""
         then do
           _ <- liftEffect $ TU.scrollToText "answer-set-display" sourceAtom
           pure unit
         else pure unit
-      -- Second, select the predicate to show its rule definitions
-      -- This will trigger the predicate modal to open
-      let pred = { name: predicateName, arity: predicateArity }
-      H.modify_ \s -> s { selectedPredicate = Just pred }
 
   NoOp ->
     pure unit  -- Do nothing, used to stop event propagation

--- a/web-ui/src/Component/TimelineGrimoire.purs
+++ b/web-ui/src/Component/TimelineGrimoire.purs
@@ -183,7 +183,7 @@ renderEvent event =
         [ HP.style $ "font-size: 12px; color: #555; margin: 4px 0; cursor: pointer; "
             <> "padding: 4px 6px; border-radius: 4px; transition: background-color 0.2s;"
         , HE.onClick \_ -> ClickTimelineEvent event
-        , HP.title "Click to navigate to this atom in the answer set and its rule definition"
+        , HP.title "Click to highlight this atom in the answer set"
         ]
         [ HH.span
             [ HP.style $ "display: inline-block; padding: 2px 6px; border-radius: 3px; "
@@ -200,7 +200,7 @@ renderEvent event =
         [ HP.style $ "font-size: 12px; color: #888; margin: 4px 0; cursor: pointer; "
             <> "padding: 4px 6px; border-radius: 4px; transition: background-color 0.2s;"
         , HE.onClick \_ -> ClickTimelineEvent event
-        , HP.title "Click to navigate to this atom"
+        , HP.title "Click to highlight this atom in the answer set"
         ]
         [ HH.text $ r.token <> " placed on " <> r.player ]
     ASP.Execution r ->
@@ -208,7 +208,7 @@ renderEvent event =
         [ HP.style $ "font-size: 12px; color: #c62828; margin: 4px 0; font-weight: bold; cursor: pointer; "
             <> "padding: 4px 6px; border-radius: 4px; transition: background-color 0.2s;"
         , HE.onClick \_ -> ClickTimelineEvent event
-        , HP.title "Click to navigate to this atom"
+        , HP.title "Click to highlight this atom in the answer set"
         ]
         [ HH.text $ r.player <> " executed" ]
 


### PR DESCRIPTION
The modal popup was too disruptive for exploration - it showed all references to a predicate (including irrelevant ones) rather than the specific rule that produced the clicked action. The scroll-to-atom highlighting remains.