### PR TITLE
Refactor night order to use global definitions from night_order.lp

### DIFF
--- a/botc.lp
+++ b/botc.lp
@@ -1,7 +1,30 @@
+% ===========================================================================
+% Night Order Derivation
+% Derive first_night_role_order/2 and other_night_role_order/2 from the
+% global night_order/3 defined in night_order.lp
+%
+% night_order(Role, FirstNightPos, OtherNightPos) is the canonical source.
+% Roles with position 0 do not wake during that phase.
+% ===========================================================================
+
+% Derive first night role order from global night_order/3
+% Only include roles that actually wake on first night (position > 0)
+first_night_role_order(Role, Pos) :-
+    night_order(Role, Pos, _),
+    Pos > 0.
+
+% Derive other nights role order from global night_order/3
+% Only include roles that actually wake on other nights (position > 0)
+other_night_role_order(Role, Pos) :-
+    night_order(Role, _, Pos),
+    Pos > 0.
+
+% ===========================================================================
 % Time points for the game
 % We use structured time: night(N, RoleOrder, Substep)
 % night(1, 0, 0) is the setup state before any role acts
 % night(1, R, S) is substep S of the role at position R in the night order
+% ===========================================================================
 
 time(night(1, 0, 0)).  % setup state before any actions on night 1
 

--- a/roles/tb/base.lp
+++ b/roles/tb/base.lp
@@ -10,25 +10,6 @@ tb_outsider(butler; drunk; recluse; saint).
 tb_minion(poisoner; spy; scarlet_woman; baron).
 tb_demon(imp).
 
-% First Night Order
-first_night_role_order(poisoner, 1).
-first_night_role_order(washerwoman, 2).
-first_night_role_order(librarian, 3).
-first_night_role_order(investigator, 4).
-first_night_role_order(chef, 5).
-first_night_role_order(empath, 6).
-first_night_role_order(fortune_teller, 7).
-first_night_role_order(butler, 8).
-first_night_role_order(spy, 9).
-
-% Other Night Order
-other_night_role_order(poisoner, 1).
-other_night_role_order(monk, 2).
-other_night_role_order(scarlet_woman, 3).
-other_night_role_order(imp, 4).
-other_night_role_order(ravenkeeper, 5).
-other_night_role_order(empath, 6).
-other_night_role_order(fortune_teller, 7).
-other_night_role_order(undertaker, 8).
-other_night_role_order(butler, 9).
-other_night_role_order(spy, 10).
+% Night order is derived from the global night_order.lp file.
+% See botc.lp for the derivation rules that create first_night_role_order/2
+% and other_night_role_order/2 from night_order/3.


### PR DESCRIPTION
Replace ad-hoc per-script night order facts with derivation rules that use the global night_order/3 predicate from night_order.lp.

Changes:
- botc.lp: Add derivation rules for first_night_role_order/2 and other_night_role_order/2 from night_order/3
- tb.lp: Remove hardcoded first_night_role_order and other_night_role_order facts (these are now derived automatically)

This allows any script to use the same consistent night ordering by simply including night_order.lp. The global ordering ensures cross-script compatibility and makes it trivial to derive the correct night order for any subset of roles (custom scripts).