### PR TITLE
Add click-to-navigate for #include directives in editor

### DIFF
--- a/web-ui/src/TextareaUtils.js
+++ b/web-ui/src/TextareaUtils.js
@@ -190,3 +190,36 @@ function escapeHtml(text) {
   div.textContent = text;
   return div.innerHTML;
 }
+
+// Detect if the cursor is on an #include directive and return the file path
+// Returns null if not on an include, or the file path string if found
+export const getIncludeAtCursorImpl = (elementId) => () => {
+  const textarea = document.getElementById(elementId);
+  if (!textarea) return null;
+
+  const text = textarea.value;
+  const cursorPos = textarea.selectionStart;
+
+  // Find the line containing the cursor
+  const lines = text.split('\n');
+  let charCount = 0;
+  let currentLine = '';
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineEnd = charCount + lines[i].length;
+    if (cursorPos >= charCount && cursorPos <= lineEnd) {
+      currentLine = lines[i];
+      break;
+    }
+    charCount += lines[i].length + 1; // +1 for newline
+  }
+
+  // Check if the line is an #include directive
+  // Pattern: #include "filename".
+  const includeMatch = currentLine.match(/#include\s+"([^"]+)"\s*\./);
+  if (includeMatch) {
+    return includeMatch[1]; // Return the filename
+  }
+
+  return null;
+};

--- a/web-ui/src/TextareaUtils.purs
+++ b/web-ui/src/TextareaUtils.purs
@@ -3,10 +3,13 @@ module TextareaUtils
   , focusTextarea
   , scrollToText
   , scrollToTextInChild
+  , getIncludeAtCursor
   ) where
 
 import Prelude
 
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
 import Effect (Effect)
 
 -- | Scroll a textarea to a specific line and select/highlight it
@@ -37,3 +40,10 @@ foreign import scrollToTextInChildImpl :: String -> Int -> String -> Effect Bool
 
 scrollToTextInChild :: String -> Int -> String -> Effect Boolean
 scrollToTextInChild = scrollToTextInChildImpl
+
+-- | Detect if cursor is on an #include directive and return the file path
+-- | Takes the element ID, returns Just filepath if on an include, Nothing otherwise
+foreign import getIncludeAtCursorImpl :: String -> Effect (Nullable String)
+
+getIncludeAtCursor :: String -> Effect (Maybe String)
+getIncludeAtCursor elementId = toMaybe <$> getIncludeAtCursorImpl elementId


### PR DESCRIPTION
When the user clicks on an #include "filepath" directive in the source editor textarea, a dialog now appears asking if they want to navigate to that file. This enables editing of included files in subdirectories that are not immediately visible in the tab bar.

Changes:
- Add getIncludeAtCursor FFI function to detect #include at cursor
- Add navigateIncludeTarget state for the confirmation dialog
- Add TextareaClicked action with include path resolution
- Render confirmation dialog showing the resolved file path
- Support relative path resolution (same as Clingo's include behavior)