### PR TITLE
Add game end conditions to stop timeline after demon death

### DIFF
--- a/botc.lp
+++ b/botc.lp
@@ -110,10 +110,12 @@ between(T1, T2) :-
 next(T, day(N, 0)) :- final_night_time(N, T), day_number(N).
 
 % Within a day: day(N, 0) -> day(N, exec)
-next(day(N, 0), day(N, exec)) :- day_number(N).
+% Don't transition if evil already won at start of day
+next(day(N, 0), day(N, exec)) :- day_number(N), not game_over(day(N, 0)).
 
 % Day N ends, night N+1 begins
-next(day(N, exec), night(N+1, 0, 0)) :- day_number(N), night_number(N+1).
+% Don't transition to next night if game ended (good wins from execution, or evil wins)
+next(day(N, exec), night(N+1, 0, 0)) :- day_number(N), night_number(N+1), not game_over(day(N, exec)).
 
 player(P) :- name(P), chair(P,C), C < player_count.
 
@@ -476,7 +478,8 @@ final_night_time(N, T) :-
     not next(T, T2) : time(T2), T2 = night(N, _, _).
 
 % Alive at start of night N+1 = alive at end of day N
-alive(P, night(N+1, 0, 0)) :- alive(P, day(N, exec)), night_number(N+1).
+% Don't propagate if game ended on day N
+alive(P, night(N+1, 0, 0)) :- alive(P, day(N, exec)), night_number(N+1), not game_over(day(N, exec)).
 
 % ===========================================================================
 % Day Time Structure (simplified)

--- a/game_end.lp
+++ b/game_end.lp
@@ -1,0 +1,67 @@
+% ===========================================================================
+% Game End Conditions
+% ===========================================================================
+% The game ends when either Good or Evil wins.
+%
+% Good wins when:
+%   - The Demon dies and no one becomes the new Demon
+%     (no Scarlet Woman trigger, no starpass)
+%
+% Evil wins when:
+%   - Only 2 players remain alive and the Demon is one of them
+%
+% Future: Mastermind, Evil Twin, and other special win conditions
+% ===========================================================================
+
+% ---------------------------------------------------------------------------
+% Good Wins: Demon dies unreplaced
+% ---------------------------------------------------------------------------
+
+% The demon dies unreplaced when executed and no one becomes the new demon
+% Note: starpass only triggers from self-kill at night, not from execution
+demon_dies_unreplaced(N) :-
+    day_number(N),
+    executed(P, N),
+    assigned(0, P, R), demon(R),
+    not sw_becomes_demon(_, N).
+
+% Good wins at the moment the demon is executed without replacement
+good_wins(day(N, exec)) :- demon_dies_unreplaced(N).
+
+% ---------------------------------------------------------------------------
+% Evil Wins: Two or fewer players alive
+% ---------------------------------------------------------------------------
+
+% Count of alive players at start of day
+alive_at_day_start(N, C) :-
+    day_number(N),
+    C = #count { P : alive(P, day(N, 0)) }.
+
+% Evil wins at start of day if 2 or fewer alive and demon is among them
+evil_wins(day(N, 0)) :-
+    day_number(N),
+    alive_at_day_start(N, C), C <= 2,
+    alive(D, day(N, 0)),
+    current_demon(D, N).
+
+% ---------------------------------------------------------------------------
+% Game Over: Derived from win conditions
+% ---------------------------------------------------------------------------
+
+% Game is over at the moment someone wins
+game_over(T) :- good_wins(T).
+game_over(T) :- evil_wins(T).
+
+% Game over propagates forward through next (for any remaining time points)
+game_over(T2) :- game_over(T1), next(T1, T2).
+
+% ---------------------------------------------------------------------------
+% Convenience predicates for UI/debugging
+% ---------------------------------------------------------------------------
+
+% Who won and when
+winner(good, T) :- good_wins(T), not evil_wins(T2) : T2 = day(N, 0), good_wins(day(N, exec)).
+winner(evil, T) :- evil_wins(T).
+
+% Game is active (not yet over) at time T
+game_active(T) :- time(T), not game_over(T).

--- a/tb.lp
+++ b/tb.lp
@@ -33,3 +33,6 @@
 
 % Demon
 #include "roles/tb/demons/imp.lp".
+
+% Game end conditions (depends on demon/minion logic above)
+#include "game_end.lp".


### PR DESCRIPTION
- Add game_end.lp with good_wins/evil_wins/game_over predicates
- Good wins when demon is executed and no replacement (no SW trigger)
- Evil wins when 2 or fewer players alive at start of day with demon alive
- Modify next/2 transitions in botc.lp to not cross game_over points
- Modify alive propagation to not continue after game ends

This fixes the issue where the timeline would continue generating
nights and days after the demon was executed, even when no Scarlet
Woman (or other demon-replacement mechanism) was in play.