### PR TITLE
Reorder UI panels: Grimoire | Bag | Script

### DIFF
--- a/web-ui/src/Component/TimelineGrimoire.purs
+++ b/web-ui/src/Component/TimelineGrimoire.purs
@@ -234,13 +234,11 @@ render state =
             [ HH.text "Timeline" ]
         , renderTimeline state
         ]
-    -- Grimoire area: Bag | Grimoire | Script
+    -- Grimoire area: Grimoire | Bag | Script
     , HH.div
         [ HP.style "flex: 2; min-width: 400px; display: flex; gap: 10px; align-items: stretch;" ]
-        [ -- Bag panel (left of grimoire, collapsible)
-          renderBagPanel state gameState
-        -- Grimoire panel (center)
-        , HH.div
+        [ -- Grimoire panel (left)
+          HH.div
             [ HP.style $ "flex: 1;"
                 <> if isJust state.dragging then " cursor: grabbing;" else ""
             ]
@@ -269,7 +267,9 @@ render state =
                 then renderGrimoire state
                 else renderHtmlGrimoire state
             ]
-        -- Script panel (right of grimoire, collapsible)
+        -- Bag panel (center, collapsible)
+        , renderBagPanel state gameState
+        -- Script panel (right, collapsible)
         , renderScriptPanel state
         ]
     ]


### PR DESCRIPTION
Move the grimoire to the left side, with the bag in the center between
the grimoire and script. This makes it easier to drag tokens from the
script directly to the bag since they are now adjacent.