### PR TITLE
Fix execution token display truncation in grimoire view

### DIFF
--- a/web-ui/src/Component/TimelineGrimoire.purs
+++ b/web-ui/src/Component/TimelineGrimoire.purs
@@ -1236,6 +1236,12 @@ abbreviateToken t = case t of
   "but_master" -> "BUT"
   "sla_no_ability" -> "SLA"
   "drunk_is_drunk" -> "DRUNK"
+  -- Execution day tokens
+  "ex_d1" -> "EX1"
+  "ex_d2" -> "EX2"
+  "ex_d3" -> "EX3"
+  "ex_d4" -> "EX4"
+  "ex_d5" -> "EX5"
   _ -> takeChars 3 t
   where
     takeChars n s = if S.length s <= n then s else fold (take n (S.split (Pattern "") s))


### PR DESCRIPTION
The abbreviateToken function was falling through to the default case
for execution tokens (ex_d1, ex_d2, etc.), which only takes 3 characters.
This resulted in "ex_d3" displaying as "ex_" instead of showing the day.

Add explicit cases for ex_d1 through ex_d5 that display as EX1-EX5,
making the execution day visible in the token.