### PR TITLE
Bound bag and script panel heights to grimoire height

### DIFF
--- a/web-ui/src/Component/TimelineGrimoire.purs
+++ b/web-ui/src/Component/TimelineGrimoire.purs
@@ -294,6 +294,7 @@ renderBagPanel state gameState =
   HH.div
     [ HP.style $ "min-width: " <> (if state.bagCollapsed then "40px" else "150px") <> "; "
         <> "display: flex; flex-direction: column; "
+        <> "overflow: hidden; "  -- Prevent content from pushing height beyond grimoire
         <> "transition: min-width 0.2s ease-in-out;"
     ]
     [ -- Header with collapse toggle
@@ -370,6 +371,7 @@ renderScriptPanel state =
   HH.div
     [ HP.style $ "min-width: " <> (if state.scriptCollapsed then "40px" else "160px") <> "; "
         <> "display: flex; flex-direction: column; "
+        <> "overflow: hidden; "  -- Prevent content from pushing height beyond grimoire
         <> "transition: min-width 0.2s ease-in-out;"
     ]
     [ -- Header with collapse toggle


### PR DESCRIPTION
Add overflow: hidden to bag and script panel containers to prevent
their content from pushing the height beyond the grimoire. This ensures
the panels are upper-bounded by the grimoire height while still
stretching to match it when the grimoire is taller.