### PR TITLE
Fix: Don't execute players after game has ended

### DIFF
--- a/inst.lp
+++ b/inst.lp
@@ -18,7 +18,8 @@ needs_night(3).
 % received(rob, washerwoman).
 
 % Town executes exactly one living player at the end of each day
-{ executed(P, N) : alive(P, day(N, 0)) } = 1 :- day_number(N).
+% (unless the game has already ended at the start of this day)
+{ executed(P, N) : alive(P, day(N, 0)) } = 1 :- day_number(N), not game_over(day(N, 0)).
 
 % ===========================================================================
 % House rules: Discourage unrealistic but technically legal states


### PR DESCRIPTION
The executed choice rule in inst.lp was not checking for game_over,
causing the solver to still select executions on days when the game
should have already ended (e.g., evil wins at day start with 2 players).

Add not game_over(day(N, 0)) condition to the execution choice rule.