### PR TITLE
Optimize bag drag-drop: use direct bag/1 facts instead of assert_drawn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,34 @@ View specific run:
 curl -s "https://api.github.com/repos/pnkfelix/botc-asp/actions/runs/<run_id>/jobs"
 ```
 
+## UI Drag-and-Drop Design Principle
+
+**Core principle**: UI drag-and-drop actions can introduce constraints on what states are legal, but will never introduce new states that were previously considered impossible.
+
+This means the UI selects from existing possibilities in the ASP choice sets, rather than creating arbitrary new facts.
+
+### Optimization: Direct Facts vs Assertions
+
+For roles that are already in a choice set (like most roles in the `bag/1` choice rule), the UI can directly state facts:
+- `bag(chef).` - directly asserts chef is in the bag
+
+For roles with special conditions (like `never_in_bag` roles), the UI must use assertion predicates:
+- `assert_distrib(drunk).` - constrains solver to make `distrib(drunk)` true
+
+The direct fact approach is an optimization because:
+1. It provides the same semantic result (role ends up in bag)
+2. The solver can fix the atom during grounding rather than deriving it via constraint propagation
+3. It's conceptually cleaner—the UI is stating what IS true, not what MUST become true
+
+### Implementation (ClingoDemo.purs)
+
+When dropping a role onto the bag:
+```purescript
+let newConstraint = if isNeverInBag
+      then "assert_distrib(" <> role <> ")."  -- Must use assertion
+      else "bag(" <> role <> ")."              -- Direct fact (optimized)
+```
+
 ## Known Limitations
 
 - Clingo WASM is large (~2MB); initial page load may be slow

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ npm run dev         # Watch mode with live reload
 
 6. **Modular role definitions**: Each role is defined in its own file under `roles/`, making it easy to understand, test, and extend individual role mechanics.
 
+7. **UI actions select, not create**: Drag-and-drop operations introduce constraints on what states are legal, but never introduce new states that were previously considered impossible. For roles already in the choice set (non-never-in-bag roles), the UI can directly state facts like `bag(role).` as an optimization. For special roles like Drunk that require indirect reasoning, the UI uses assertion predicates that constrain the solver.
+
 ## ASP Concepts
 
 **Answer Set Programming** is a declarative programming paradigm where you:

--- a/web-ui/src/Component/ClingoDemo.purs
+++ b/web-ui/src/Component/ClingoDemo.purs
@@ -1206,13 +1206,18 @@ handleAction = case _ of
           let instContent = fromMaybe "" $ Map.lookup "inst.lp" state.files
           -- Check if dropping onto the bag (special target)
           if toPlayer == "__bag__" then do
-            -- Dropping onto the bag: add assert_drawn or assert_distrib
-            -- Roles marked never_in_bag (like drunk) should use assert_distrib instead
+            -- Dropping onto the bag: add bag/1 fact or assert_distrib
+            -- Roles marked never_in_bag (like drunk) must use assert_distrib because
+            -- they can't appear in bag/1 (excluded by choice rule condition).
+            -- For normal roles, we directly state bag(role) as a fact rather than
+            -- using assert_drawn(role) - this is an optimization since the role is
+            -- already in the choice set, so we're selecting from existing possibilities
+            -- rather than introducing new constraints.
             let neverInBagRoles = ["drunk", "marionette"]  -- Roles that can't be physically in the bag
             let isNeverInBag = elem role neverInBagRoles
             let newConstraint = if isNeverInBag
                   then "assert_distrib(" <> role <> ")."
-                  else "assert_drawn(" <> role <> ")."
+                  else "bag(" <> role <> ")."
             let undoEntry = { instLpContent: instContent
                             , description: "Add " <> role <> " to bag"
                             }


### PR DESCRIPTION
For non-never-in-bag roles dragged into the bag, generate `bag(role).`
directly instead of `assert_drawn(role).`. This is semantically
equivalent but allows the solver to fix the atom during grounding
rather than deriving it through constraint propagation.

Never-in-bag roles (drunk, marionette) still use assert_distrib since
they can't appear in the bag/1 choice set.

Also document the UI design principle: drag-and-drop actions select
from existing possibilities rather than creating new states.