### PR TITLE
Add role distribution support for 5-6 player games

### DIFF
--- a/botc.lp
+++ b/botc.lp
@@ -359,17 +359,21 @@ role(X) :- demon(X).
 reminder(poi_poisoned).
 
 % the legal baseline role distrbutions are:
+% 5 players => 1 demon, 1 minion, 0 outsiders, 3 townsfolk
+% 6 players => 1 demon, 1 minion, 1 outsider, 3 townsfolk
 % 7 players => 1 demon, 1 minion, 0 outsiders, 5 townsfolk
 
+base_townsfolk(3) :- 5 <= player_count <= 6.
 base_townsfolk(5) :- 7 <= player_count <= 9.
 base_townsfolk(7) :- 10 <= player_count <= 12.
 base_townsfolk(9) :- 13 <= player_count <= 15.
 
+base_outsider(player_count - 5) :- 5 <= player_count <= 6.
 base_outsider(player_count - 7) :- 7 <= player_count <= 9.
 base_outsider(player_count - 10) :- 10 <= player_count <= 12.
 base_outsider(player_count - 13) :- 13 <= player_count <= 15.
 
-base_minion(1) :-  7 <= player_count <= 9.
+base_minion(1) :-  5 <= player_count <= 9.
 base_minion(2) :- 10 <= player_count <= 12.
 base_minion(3) :- 13 <= player_count <= 15.
 

--- a/tb_tests/sat_05players_basic.lp
+++ b/tb_tests/sat_05players_basic.lp
@@ -1,0 +1,19 @@
+% Test: 5-player game should be satisfiable with correct role distribution
+% Expected: SATISFIABLE with 3 townsfolk, 0 outsiders, 1 minion, 1 demon
+
+#include "botc.lp".
+#include "tb.lp".
+#include "players.lp".
+
+#const player_count = 5.
+
+% Only run through night 1 for this test
+needs_night(1).
+
+% For 5 players, execution is optional (skip execution constraint from inst.lp)
+% In a real game, day 1 execution happens but we don't need it for role distribution test
+
+#show distrib/1.
+#show bag/1.
+#show game_chair/2.
+#show assigned/3.

--- a/web-ui/src/Component/ClingoDemo.purs
+++ b/web-ui/src/Component/ClingoDemo.purs
@@ -304,7 +304,7 @@ getGrimoireAtoms state =
       getEarlyAtomsFiltered state.files
 
 -- | Get early atoms filtered by player_count
--- | Only includes game_chair atoms where chair position <= player_count
+-- | Only includes game_chair atoms where chair position < player_count (0-indexed)
 getEarlyAtomsFiltered :: Map.Map String String -> { atoms :: Array String, isEarly :: Boolean, modelInfo :: String }
 getEarlyAtomsFiltered files =
   let


### PR DESCRIPTION
The solver was producing inconsistent answer sets for 5-player games
because the role distribution rules only covered 7-15 players.

Changes:
- Add base_townsfolk, base_outsider, base_minion rules for 5-6 players
  - 5 players: 3 townsfolk, 0 outsiders, 1 minion, 1 demon
  - 6 players: 3 townsfolk, 1 outsider, 1 minion, 1 demon
- Fix inconsistent comment in ClingoDemo.purs (< vs <=)
- Add test file for 5-player games