### PR TITLE
Fix clingo infinite loop by removing --opt-mode=optN

### DIFF
--- a/web-ui/src/Clingo.js
+++ b/web-ui/src/Clingo.js
@@ -10,7 +10,7 @@ export const initImpl = (wasmUrl) => () => {
 };
 
 export const runImpl = (program) => (numModels) => () =>
-  clingo.run(program, numModels, ["--opt-mode=optN"]);
+  clingo.run(program, numModels);
 
 export const restartImpl = (wasmUrl) => () => {
   // Terminate the worker and re-initialize


### PR DESCRIPTION
The optN mode was added for optimization with weak constraints, but
no weak constraints exist in the codebase. Without weak constraints,
optN mode treats all models as equally optimal and attempts to
enumerate ALL models before returning, causing the solver to hang.

Removing this flag restores normal enumeration behavior.