### PR TITLE
Re-enable diff computation (fix merge issue from PR #138)

### DIFF
--- a/web-ui/src/Component/ClingoDemo.purs
+++ b/web-ui/src/Component/ClingoDemo.purs
@@ -1284,9 +1284,8 @@ handleAction = case _ of
     let numModels = case trim state.modelLimit of
           "" -> 5  -- Default to 5 models when field is empty
           s -> fromMaybe 5 $ Int.fromString s
-    -- DISABLED: Diff computation was causing hangs
-    -- let diffResult = computeFileDiff state.files
-    let diffResult = { summary: "Diff disabled", fileDiffs: [] }
+    -- Compute the diff description before running (for timing table)
+    let diffResult = computeFileDiff state.files
     -- Build file resolver for #include directives using the virtual filesystem
     let resolver filename = Map.lookup filename state.files
     -- Get the current file's content (the entry point that #includes other files)


### PR DESCRIPTION
The merge of PR #138 only included the changes inside computeFileDiff (skipping comment stripping) but didn't re-enable calling the function. This resulted in "Diff disabled" still showing in the timing table.