### PR TITLE
Fix clingo hang by restoring original simple diff implementation

### DIFF
--- a/web-ui/src/Component/ClingoDemo.purs
+++ b/web-ui/src/Component/ClingoDemo.purs
@@ -6,7 +6,6 @@ import AnswerSetParser as AnswerSet
 import AspParser as ASP
 import BuildInfo as BI
 import Clingo as Clingo
-import Diff as Diff
 import Data.Map as Map
 import Data.Set as Set
 import Component.TimelineGrimoire as TG
@@ -45,10 +44,11 @@ type UndoEntry =
   , description :: String     -- Human-readable description of the change
   }
 
--- | A single file's diff (comment-stripped comparison using jsdiff)
+-- | A single file's diff (comment-stripped comparison)
 type FileDiff =
-  { fileName :: String              -- Name of the file that changed
-  , diffLines :: Array Diff.DiffLine  -- Computed diff lines with status
+  { fileName :: String         -- Name of the file that changed
+  , originalLines :: Array String  -- Original lines (comments stripped)
+  , currentLines :: Array String   -- Current lines (comments stripped)
   }
 
 -- | An entry in the timing history table
@@ -213,40 +213,65 @@ initialState =
 
 -- | Strip ASP comments from a string (lines starting with %)
 -- | Also strips empty lines and trims whitespace
--- | Returns the stripped content as a single string (with newlines)
-stripCommentsToString :: String -> String
-stripCommentsToString content =
+-- | Returns an array of non-comment lines
+stripComments :: String -> Array String
+stripComments content =
   let
     allLines = split (Pattern "\n") content
     -- Filter out comment lines and empty lines, trim whitespace
     nonCommentLines = filter isNonComment allLines
   in
-    intercalate "\n" (map trim nonCommentLines)
+    map trim nonCommentLines
   where
     isNonComment line =
       let trimmed = trim line
       in trimmed /= "" && String.take 1 trimmed /= "%"
 
 -- | Compute file diffs comparing current files to original embedded files
--- | Simple line-based diff implementation
+-- | Uses simple line comparison (comments stripped)
 -- | Returns both a summary string and detailed per-file diffs for the modal
 computeFileDiff :: Map.Map String String -> { summary :: String, fileDiffs :: Array FileDiff }
 computeFileDiff currentFiles =
   let
     -- Get all file paths to compare
     allPaths = fromFoldable $ Map.keys currentFiles
-    -- Compare each file and collect diffs - only for changed files
-    changedFiles = filter isChanged allPaths
-      where
-        isChanged path =
-          let current = fromMaybe "" $ Map.lookup path currentFiles
-              original = fromMaybe "" $ Map.lookup path EP.lpFilesMap
-          in current /= original
-    -- Build summaries for changed files (skip detailed diff for now to test perf)
-    summaries = map (\path -> getFileName path <> ": modified") changedFiles
+    -- Compare each file and collect diffs (with comments stripped)
+    fileDiffsAndDescs = allPaths >>= \path ->
+      let
+        current = fromMaybe "" $ Map.lookup path currentFiles
+        original = fromMaybe "" $ Map.lookup path EP.lpFilesMap
+        -- Strip comments before comparing
+        currentStripped = stripComments current
+        originalStripped = stripComments original
+      in
+        if currentStripped == originalStripped
+          then []
+          else
+            let
+              currentLen = length currentStripped
+              originalLen = length originalStripped
+              -- Simple line count difference
+              added = if currentLen > originalLen then currentLen - originalLen else 0
+              removed = if originalLen > currentLen then originalLen - currentLen else 0
+              diffDesc = if added > 0 && removed > 0
+                then "+" <> show added <> "/-" <> show removed
+                else if added > 0
+                  then "+" <> show added
+                  else if removed > 0
+                    then "-" <> show removed
+                    else "modified"
+              fileDiff = { fileName: getFileName path
+                         , originalLines: originalStripped
+                         , currentLines: currentStripped
+                         }
+            in
+              [{ desc: getFileName path <> ": " <> diffDesc, diff: fileDiff }]
+    -- Extract summaries and diffs
+    summaries = map _.desc fileDiffsAndDescs
+    diffs = map _.diff fileDiffsAndDescs
   in
     { summary: if null summaries then "No changes" else intercalate ", " summaries
-    , fileDiffs: []  -- Skip detailed diff computation for now
+    , fileDiffs: diffs
     }
 
 -- | Get files to show in tabs: root files + current file if it's in a subdirectory
@@ -1009,37 +1034,44 @@ renderDiffModal (Just entry) =
         ]
     ]
   where
-    renderFileDiff fileDiff =
+    renderFileDiff diff =
       HH.div
         [ HP.style "margin-bottom: 20px; border: 1px solid #ddd; border-radius: 4px; overflow: hidden;" ]
         [ -- File header
           HH.div
             [ HP.style "padding: 8px 12px; background: #f0f0f0; font-weight: bold; font-family: monospace; font-size: 13px; border-bottom: 1px solid #ddd;" ]
-            [ HH.text fileDiff.fileName ]
-        -- Unified diff view with colored lines
+            [ HH.text diff.fileName ]
+        -- Two-column diff view
         , HH.div
-            [ HP.style "max-height: 400px; overflow-y: auto; font-family: monospace; font-size: 12px;" ]
-            [ HH.div_ $ map renderDiffLine fileDiff.diffLines ]
+            [ HP.style "display: flex; font-family: monospace; font-size: 11px;" ]
+            [ -- Original column
+              HH.div
+                [ HP.style "flex: 1; border-right: 1px solid #ddd;" ]
+                [ HH.div
+                    [ HP.style "padding: 4px 8px; background: #ffebee; font-weight: bold; font-size: 10px; color: #c62828;" ]
+                    [ HH.text "Original" ]
+                , HH.div
+                    [ HP.style "padding: 8px; max-height: 300px; overflow-y: auto; background: #fff5f5;" ]
+                    [ HH.pre
+                        [ HP.style "margin: 0; white-space: pre-wrap; word-break: break-all;" ]
+                        [ HH.text $ intercalate "\n" diff.originalLines ]
+                    ]
+                ]
+            -- Current column
+            , HH.div
+                [ HP.style "flex: 1;" ]
+                [ HH.div
+                    [ HP.style "padding: 4px 8px; background: #e8f5e9; font-weight: bold; font-size: 10px; color: #2e7d32;" ]
+                    [ HH.text "Current" ]
+                , HH.div
+                    [ HP.style "padding: 8px; max-height: 300px; overflow-y: auto; background: #f5fff5;" ]
+                    [ HH.pre
+                        [ HP.style "margin: 0; white-space: pre-wrap; word-break: break-all;" ]
+                        [ HH.text $ intercalate "\n" diff.currentLines ]
+                    ]
+                ]
+            ]
         ]
-
-    renderDiffLine :: Diff.DiffLine -> H.ComponentHTML Action Slots m
-    renderDiffLine diffLine =
-      let
-        { prefix, bgColor, textColor } = case diffLine.status of
-          Diff.Added -> { prefix: "+ ", bgColor: "#e6ffec", textColor: "#22863a" }
-          Diff.Removed -> { prefix: "- ", bgColor: "#ffebe9", textColor: "#cb2431" }
-          Diff.Unchanged -> { prefix: "  ", bgColor: "transparent", textColor: "#24292e" }
-      in
-        HH.div
-          [ HP.style $ "padding: 2px 8px; background: " <> bgColor <> "; color: " <> textColor <> "; "
-              <> "white-space: pre-wrap; word-break: break-all; border-left: 3px solid "
-              <> (case diffLine.status of
-                    Diff.Added -> "#28a745"
-                    Diff.Removed -> "#d73a49"
-                    Diff.Unchanged -> "transparent")
-              <> ";"
-          ]
-          [ HH.text $ prefix <> diffLine.line ]
 
 -- | Render the predicate list panel (slide-in from right) with backdrop
 renderPredicatePanel :: forall m. Boolean -> Array ASP.Predicate -> H.ComponentHTML Action Slots m


### PR DESCRIPTION
## Summary
- Restores the original working diff implementation from commit 0b42e60
- Removes jsdiff library dependency that was causing infinite hangs
- Uses simple two-column side-by-side view (Original | Current) instead of unified diff

## What was wrong
The jsdiff library (or the way it was being invoked) caused the UI to hang indefinitely when clicking "Run Clingo". Even replacing jsdiff with a simple custom diff algorithm didn't fix it, suggesting the issue was in how the diff system was structured.

## The fix
Reverted to the original implementation that worked:
- `FileDiff` stores `originalLines` and `currentLines` as `Array String`
- `stripComments` returns `Array String` 
- Simple line count comparison for the summary
- No external diff library

## Test plan
- [ ] Click "Run Clingo" - should complete quickly without hanging
- [ ] Make a change to inst.lp, run again - timing table should show the file as modified
- [ ] Click a row in timing history - should show two-column diff modal
