### PR TITLE
Show actual model count in timing history table

### DIFF
--- a/web-ui/src/Component/ClingoDemo.purs
+++ b/web-ui/src/Component/ClingoDemo.purs
@@ -1043,6 +1043,13 @@ renderDiffModal (Just entry) =
         ]
     ]
   where
+    -- Format model count for modal display: "actual/max" with "+" if more exist
+    formatModalModelCount :: TimingEntry -> String
+    formatModalModelCount e =
+      let actual = show e.actualModelCount <> (if e.moreModels then "+" else "")
+          maxStr = if e.modelLimit == 0 then "all" else show e.modelLimit
+      in actual <> "/" <> maxStr
+
     renderFileDiff diff =
       let
         -- Build content-addressed sets: all unique line contents from each side
@@ -1098,13 +1105,6 @@ renderDiffModal (Just entry) =
                 ]
             ]
         ]
-  where
-    -- Format model count for modal display: "actual/max" with "+" if more exist
-    formatModalModelCount :: TimingEntry -> String
-    formatModalModelCount e =
-      let actual = show e.actualModelCount <> (if e.moreModels then "+" else "")
-          maxStr = if e.modelLimit == 0 then "all" else show e.modelLimit
-      in actual <> "/" <> maxStr
 
 -- | Render the predicate list panel (slide-in from right) with backdrop
 renderPredicatePanel :: forall m. Boolean -> Array ASP.Predicate -> H.ComponentHTML Action Slots m


### PR DESCRIPTION
The timing table now shows "found/max" for models instead of just the
max limit. For example "5/10" means 5 models were found with a limit
of 10. A "+" suffix indicates more models exist (e.g., "10+/10").

Changes:
- Add actualModelCount and moreModels fields to TimingEntry
- Extract model count info from clingo result (res."Models"."Number")
- Update table header to "Models (found/max)"
- Update both the timing table and diff modal to show actual counts