### PR TITLE
Fix Baron to add only 1 outsider for games with < 7 players

### DIFF
--- a/roles/tb/minions/baron.lp
+++ b/roles/tb/minions/baron.lp
@@ -1,3 +1,6 @@
 % Baron
+% For small games (5-6 players), Baron only swaps in 1 outsider
+% For standard games (7+ players), Baron swaps in 2 outsiders
 
-causes_outsider_mod(baron, 2).
+causes_outsider_mod(baron, 1) :- player_count < 7.
+causes_outsider_mod(baron, 2) :- player_count >= 7.

--- a/tb_tests/sat_05players_1outsider_with_baron.lp
+++ b/tb_tests/sat_05players_1outsider_with_baron.lp
@@ -1,0 +1,11 @@
+% Test: 5 players with baron should have 1 outsider (0 base + 1 from baron)
+% In small games (< 7 players), Baron only adds 1 outsider instead of 2
+#include "../botc.lp".
+#include "../tb.lp".
+#include "../players.lp".
+
+#const player_count = 5.
+
+% Baron + 1 outsider (0 base for 5 players + 1 from baron)
+assigned(0, taylor, baron).
+assigned(0, felix, drunk).

--- a/tb_tests/sat_06players_2outsiders_with_baron.lp
+++ b/tb_tests/sat_06players_2outsiders_with_baron.lp
@@ -1,0 +1,12 @@
+% Test: 6 players with baron should have 2 outsiders (1 base + 1 from baron)
+% In small games (< 7 players), Baron only adds 1 outsider instead of 2
+#include "../botc.lp".
+#include "../tb.lp".
+#include "../players.lp".
+
+#const player_count = 6.
+
+% Baron + 2 outsiders (1 base for 6 players + 1 from baron)
+assigned(0, taylor, baron).
+assigned(0, felix, drunk).
+assigned(0, kunjal, butler).

--- a/tb_tests/unsat_06players_3outsiders_with_baron.lp
+++ b/tb_tests/unsat_06players_3outsiders_with_baron.lp
@@ -1,0 +1,13 @@
+% Test: 6 players with baron CANNOT have 3 outsiders
+% In small games (< 7 players), Baron only adds 1 outsider, so max is 2 (1 base + 1 from baron)
+#include "../botc.lp".
+#include "../tb.lp".
+#include "../players.lp".
+
+#const player_count = 6.
+
+% Baron + 3 outsiders should be unsatisfiable (only 2 outsiders allowed)
+assigned(0, taylor, baron).
+assigned(0, felix, drunk).
+assigned(0, kunjal, butler).
+assigned(0, amanda, recluse).


### PR DESCRIPTION
Per Trouble Brewing rules, Baron swaps in 2 outsiders for standard games
(7+ players) but only 1 outsider for small games (5-6 players).

The previous implementation always added 2 outsiders regardless of player
count. This change makes the outsider modification conditional on player_count.

Added test cases:
- sat_05players_1outsider_with_baron: 5 players + Baron = 1 outsider
- sat_06players_2outsiders_with_baron: 6 players + Baron = 2 outsiders
- unsat_06players_3outsiders_with_baron: 6 players + Baron ≠ 3 outsiders