### PR TITLE
Add URL player_count parameter support

### DIFF
--- a/web-ui/src/UrlParams.js
+++ b/web-ui/src/UrlParams.js
@@ -1,0 +1,7 @@
+// FFI bindings for reading URL parameters
+
+// Get a URL parameter by name, returns null if not present
+export const getUrlParamImpl = (name) => () => {
+  const params = new URLSearchParams(window.location.search);
+  return params.get(name);
+};

--- a/web-ui/src/UrlParams.purs
+++ b/web-ui/src/UrlParams.purs
@@ -1,0 +1,16 @@
+module UrlParams
+  ( getUrlParam
+  ) where
+
+import Prelude
+
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
+import Effect (Effect)
+
+-- | Get a URL parameter by name
+-- | Returns Nothing if the parameter is not present
+getUrlParam :: String -> Effect (Maybe String)
+getUrlParam name = toMaybe <$> getUrlParamImpl name
+
+foreign import getUrlParamImpl :: String -> Effect (Nullable String)


### PR DESCRIPTION
Allow setting the player count via URL parameter, e.g.:
  ?player_count=12

On page load, if the parameter is present and valid, inst.lp is
automatically updated to use the specified player count. The diff
in the timing history table correctly shows the change relative to
the original embedded inst.lp.