### PR TITLE
Fix Day vs Dawn time comparison in TimePoint Ord instance

### DIFF
--- a/web-ui/src/AnswerSetParser.purs
+++ b/web-ui/src/AnswerSetParser.purs
@@ -133,7 +133,7 @@ instance ordTimePoint :: Ord TimePoint where
   compare (Dawn d) (Day n _p) =
     if d <= n then LT else GT
   compare (Day n _p) (Dawn d) =
-    if n <= d then GT else LT
+    if n < d then LT else GT
   -- Night vs Day interleaving (Night N < Dawn N < Day N)
   compare (Night n _r _s) (Day d _p) =
     -- Night n comes before Day n (and Dawn n), but after Day (n-1)


### PR DESCRIPTION
The comparison `compare (Day n) (Dawn d)` was incorrectly using
`if n <= d then GT else LT`, which caused Day 1 to compare as
greater than Dawn 2. This broke death status display: players
executed on Day 1 would not show as dead when viewing Dawn 2+
because the comparison indicated the execution happened "after"
the dawn time point.

Fixed to use `if n < d then LT else GT` so that Day N correctly
compares as less than Dawn N+1 (and later dawns), matching the
actual game time ordering: Night 1 < Dawn 1 < Day 1 < Night 2 <
Dawn 2 < Day 2 < ...