### PR TITLE
Add game over event to demarcate end of timeline

### DIFF
--- a/game_end.lp
+++ b/game_end.lp
@@ -56,6 +56,28 @@ game_over(T) :- evil_wins(T).
 % Game over propagates forward through next (for any remaining time points)
 game_over(T2) :- game_over(T1), next(T1, T2).
 
+% Game over also propagates based on day number comparison
+% This is needed because 'next' is conditional on game_over, which could break propagation
+% Evil wins at day(N, 0): game ends immediately, affects rest of day N and all later times
+game_over(day(N, exec)) :- evil_wins(day(N, 0)).
+game_over(night(N2, _, _)) :- evil_wins(day(N, 0)), night_number(N2), N2 > N.
+game_over(dawn(N2)) :- evil_wins(day(N, 0)), day_number(N2), N2 > N.
+game_over(day(N2, _)) :- evil_wins(day(N, 0)), day_number(N2), N2 > N.
+
+% Good wins at day(N, exec): game ends at execution, affects all times after day N
+game_over(night(N2, _, _)) :- good_wins(day(N, exec)), night_number(N2), N2 > N.
+game_over(dawn(N2)) :- good_wins(day(N, exec)), day_number(N2), N2 > N.
+game_over(day(N2, _)) :- good_wins(day(N, exec)), day_number(N2), N2 > N.
+
+% ---------------------------------------------------------------------------
+% Game Over Event (delta predicate for timeline rendering)
+% ---------------------------------------------------------------------------
+
+% d_game_over/2 is an explicit event marking when the game ends
+% Format: d_game_over(Time, Winner) where Winner is 'good' or 'evil'
+d_game_over(T, good) :- good_wins(T).
+d_game_over(T, evil) :- evil_wins(T).
+
 % ---------------------------------------------------------------------------
 % Convenience predicates for UI/debugging
 % ---------------------------------------------------------------------------

--- a/inst.lp
+++ b/inst.lp
@@ -63,6 +63,7 @@ needs_night(3).
 #show d_executed/2.
 #show d_died/2.
 #show d_death_announced/2.
+#show d_game_over/2.
 
 % Show dawn time points so they appear in the timeline
 #show time(dawn(N)) : day_number(N).

--- a/roles/tb/demons/imp.lp
+++ b/roles/tb/demons/imp.lp
@@ -4,12 +4,15 @@ other_night_substep(imp, 1, st_asks(choose_target)).
 other_night_substep(imp, 2, player_chooses(kill_target)).
 other_night_substep(imp, 3, st_places(imp_dead)).
 
+% Imp chooses a target each night (nights after the first)
+% Only if: game is still active at night start, and Imp is alive
 { player_chooses(imp, Imp, point(P), T) : player(P) } = 1 :-
     T = night(N, RoleOrd, 2),
     night_number(N), N > 1,
     other_night_role_order(imp, RoleOrd),
     current_demon(Imp, N),
-    alive(Imp, night(N, 0, 0)).
+    alive(Imp, night(N, 0, 0)),
+    game_active(night(N, 0, 0)).
 
 % House rule: Imp cannot target itself if all minions are dead
 :- player_chooses(imp, Imp, point(Imp), night(N, RoleOrd, 2)),

--- a/web-ui/src/Component/TimelineGrimoire.purs
+++ b/web-ui/src/Component/TimelineGrimoire.purs
@@ -619,8 +619,10 @@ eventAtTime :: ASP.TimePoint -> ASP.TimelineEvent -> Boolean
 eventAtTime t (ASP.RoleAction r) = r.time == t
 eventAtTime t (ASP.TokenPlaced r) = r.time == t
 eventAtTime t (ASP.Death d) = d.time == t
+eventAtTime t (ASP.GameOverEvent g) = g.time == t
 eventAtTime (ASP.Day d _) (ASP.Execution e) = e.day == d  -- Executions appear under their day
 eventAtTime _ (ASP.Execution _) = false
+eventAtTime _ (ASP.GameOverEvent _) = false
 
 -- | Render a single event (clickable for navigation)
 renderEvent :: forall cs m. ASP.TimelineEvent -> H.ComponentHTML Action cs m
@@ -667,6 +669,17 @@ renderEvent event =
         , HP.title "Click to highlight this atom in the answer set"
         ]
         [ HH.text $ r.player <> " died" ]
+    ASP.GameOverEvent r ->
+      HH.div
+        [ HP.style $ "font-size: 14px; margin: 8px 0; font-weight: bold; cursor: pointer; "
+            <> "padding: 8px 12px; border-radius: 6px; transition: background-color 0.2s; "
+            <> "background: " <> (if r.winner == "good" then "#e8f5e9" else "#ffebee") <> "; "
+            <> "color: " <> (if r.winner == "good" then "#2e7d32" else "#c62828") <> "; "
+            <> "border: 2px solid " <> (if r.winner == "good" then "#4caf50" else "#f44336") <> ";"
+        , HE.onClick \_ -> ClickTimelineEvent event
+        , HP.title "Click to highlight this atom in the answer set"
+        ]
+        [ HH.text $ "🏆 GAME OVER - " <> (if r.winner == "good" then "Good" else "Evil") <> " wins!" ]
 
 -- | Render the grimoire (players in a circle)
 renderGrimoire :: forall cs m. State -> H.ComponentHTML Action cs m
@@ -1417,6 +1430,11 @@ handleAction = case _ of
           ASP.Death r ->
             { sourceAtom: r.sourceAtom
             , predicateName: "d_died"
+            , predicateArity: 2
+            }
+          ASP.GameOverEvent r ->
+            { sourceAtom: r.sourceAtom
+            , predicateName: "d_game_over"
             , predicateArity: 2
             }
     -- Emit the output event


### PR DESCRIPTION
- Add d_game_over/2 delta predicate in game_end.lp to explicitly mark when
  the game ends (with winner: 'good' or 'evil')
- Fix game_over propagation: ensure game_over is true for all time points
  after a win, not just those reachable via 'next' (which is conditional
  on game_over, breaking propagation)
- Prevent Imp from targeting when game is already over by adding
  game_active(night(N, 0, 0)) check to the targeting rule
- Add d_game_over/2 to #show directives in inst.lp
- Update AnswerSetParser.purs to parse d_game_over atoms and create
  GameOverEvent timeline events
- Update TimelineGrimoire.purs to render game over events with distinctive
  styling (green for good wins, red for evil wins)

This fixes the issue where events would continue past the game end state,
such as the demon targeting players when only two remained.