### PR TITLE
Update spago.lock to include web-pointerevents and web-touchevents

### DIFF
--- a/web-ui/spago.lock
+++ b/web-ui/spago.lock
@@ -20,7 +20,9 @@
             "prelude",
             "strings",
             "tuples",
-            "web-html"
+            "web-html",
+            "web-pointerevents",
+            "web-touchevents"
           ],
           "build_plan": [
             "aff",


### PR DESCRIPTION
The lock file was missing these two direct dependencies that were added
to spago.yaml, causing spago to regenerate the lock file on every CI run.
This commit eliminates that overhead and ensures reproducible builds.