### PR TITLE
Add syntax highlighting for .lp files

### DIFF
--- a/web-ui/dist/index.html
+++ b/web-ui/dist/index.html
@@ -30,6 +30,26 @@
                 animation: octocat-wave 560ms ease-in-out;
             }
         }
+
+        /* Syntax highlighting for ASP/LP code */
+        .lp-comment {
+            color: #6a9955;  /* Green - comments */
+            font-style: italic;
+        }
+        .lp-directive {
+            color: #c586c0;  /* Purple - #include, #const, etc. */
+            font-weight: bold;
+        }
+        .lp-keyword {
+            color: #569cd6;  /* Blue - :-, not, :~ */
+            font-weight: bold;
+        }
+        .lp-variable {
+            color: #ce9178;  /* Orange/brown - Variables (capitalized) */
+        }
+        .lp-string {
+            color: #d69d85;  /* Light brown - string literals */
+        }
     </style>
 </head>
 <body>

--- a/web-ui/src/TextareaUtils.purs
+++ b/web-ui/src/TextareaUtils.purs
@@ -4,6 +4,9 @@ module TextareaUtils
   , scrollToText
   , scrollToTextInChild
   , getIncludeAtCursor
+  , highlightLP
+  , syncScroll
+  , updateHighlightOverlay
   ) where
 
 import Prelude
@@ -47,3 +50,25 @@ foreign import getIncludeAtCursorImpl :: String -> Effect (Nullable String)
 
 getIncludeAtCursor :: String -> Effect (Maybe String)
 getIncludeAtCursor elementId = toMaybe <$> getIncludeAtCursorImpl elementId
+
+-- | Apply syntax highlighting to LP/ASP code
+-- | Returns HTML string with span elements for different token types
+foreign import highlightLPImpl :: String -> Effect String
+
+highlightLP :: String -> Effect String
+highlightLP = highlightLPImpl
+
+-- | Synchronize scroll position from textarea to overlay element
+-- | Takes textarea ID and overlay ID
+foreign import syncScrollImpl :: String -> String -> Effect Unit
+
+syncScroll :: String -> String -> Effect Unit
+syncScroll = syncScrollImpl
+
+-- | Update the syntax highlight overlay with highlighted code
+-- | Takes textarea ID, overlay ID, and the code content
+-- | Also sets up scroll synchronization
+foreign import updateHighlightOverlayImpl :: String -> String -> String -> Effect Unit
+
+updateHighlightOverlay :: String -> String -> String -> Effect Unit
+updateHighlightOverlay = updateHighlightOverlayImpl


### PR DESCRIPTION
Implements basic syntax highlighting using a transparent textarea overlay:
- Comments (% ...) in green italic
- Directives (#include, #const, etc.) in purple bold
- Keywords (:-, not, :~) in blue bold
- Variables (capitalized words) in orange

Uses a pre element behind a transparent textarea for smooth editing experience while displaying highlighted code. Scroll positions are synchronized between the textarea and overlay.