### PR TITLE
Fix evil_wins game over event not appearing in timeline

### DIFF
--- a/tb_tests/sat_evil_wins_two_alive.lp
+++ b/tb_tests/sat_evil_wins_two_alive.lp
@@ -1,0 +1,41 @@
+% Test: Evil wins when only 2 players are alive at start of day, with demon among them
+% This tests the evil_wins rule in game_end.lp
+%
+% Scenario: 4 players
+% - Start: felix (imp), alice (poisoner), bob (washerwoman), carol (chef)
+% - Day 1: Execute alice (3 remaining)
+% - Night 2: Imp kills bob (2 remaining at dawn 2)
+% - Day 2, 0: 2 alive (felix=demon, carol=townsfolk) = EVIL WINS
+
+#const player_count = 4.
+
+#include "../botc.lp".
+#include "../tb.lp".
+#include "../players.lp".
+
+needs_night(2).
+
+% Fixed seating
+chair(felix, 0).
+chair(alice, 1).
+chair(bob, 2).
+chair(carol, 3).
+
+% Fixed role assignments
+assigned(0, felix, imp).
+assigned(0, alice, poisoner).
+assigned(0, bob, washerwoman).
+assigned(0, carol, chef).
+
+% Day 1: Execute alice
+executed(alice, 1).
+
+% Night 2: Imp kills bob
+player_chooses(imp, felix, point(bob), night(2, 4, 2)).
+
+% Day 2, 0: 2 alive (felix=demon, carol=townsfolk)
+% Evil should win at the start of day 2
+:- not evil_wins(day(2, 0)).
+
+% Also verify d_game_over event fires
+:- not d_game_over(day(2, 0), evil).

--- a/web-ui/src/Component/TimelineGrimoire.purs
+++ b/web-ui/src/Component/TimelineGrimoire.purs
@@ -179,6 +179,7 @@ getAllTimePoints atoms =
     getTimePointFromAtom (ASP.PlayerChooses _ _ _ t) = Just t
     getTimePointFromAtom (ASP.ActingRole t _) = Just t
     getTimePointFromAtom (ASP.Executed _ d) = Just (ASP.Day d "exec")  -- Executions happen during day
+    getTimePointFromAtom (ASP.GameOver t _) = Just t  -- Game over at start of day (evil) or exec (good)
     getTimePointFromAtom _ = Nothing
 
 -- | Find the original source string for an atom matching a given time point


### PR DESCRIPTION
The getTimePointFromAtom function was missing a case for GameOver atoms, causing their time points to not be added to allTimePoints. This meant:
- good_wins at day(N, exec) was visible (time point added via Executed)
- evil_wins at day(N, 0) was invisible (no handler for GameOver)

Add GameOver case to extract its time point, ensuring evil wins events appear in the timeline at the correct time (start of day).

Also add test case sat_evil_wins_two_alive.lp to verify evil_wins logic.