### PR TITLE
Fix code view scrolling regression from syntax highlighting

### DIFF
--- a/web-ui/src/Component/ClingoDemo.purs
+++ b/web-ui/src/Component/ClingoDemo.purs
@@ -538,7 +538,7 @@ render state =
                 , HP.style $ "position: absolute; top: 0; left: 0; right: 0; bottom: 0; "
                     <> "margin: 0; padding: 10px; border: 1px solid transparent; "
                     <> "font-family: monospace; font-size: 12px; line-height: inherit; "
-                    <> "overflow: auto; pointer-events: none; white-space: pre-wrap; "
+                    <> "overflow: hidden; pointer-events: none; white-space: pre-wrap; "
                     <> "word-wrap: break-word; color: #333; background: white; "
                     <> "border-radius: 4px;"
                 ]

--- a/web-ui/src/TextareaUtils.js
+++ b/web-ui/src/TextareaUtils.js
@@ -321,6 +321,13 @@ export const updateHighlightOverlayImpl = (textareaId) => (overlayId) => (code) 
   // Add an extra newline at the end to match textarea scrolling behavior
   overlay.innerHTML = highlightedLines.join('\n') + '\n';
 
+  // Sync scroll position immediately after updating content
+  // This is critical because innerHTML update can reset scroll position
+  if (textarea) {
+    overlay.scrollTop = textarea.scrollTop;
+    overlay.scrollLeft = textarea.scrollLeft;
+  }
+
   // Set up scroll sync if not already done
   if (textarea && !textarea.dataset.scrollSyncSetup) {
     textarea.dataset.scrollSyncSetup = 'true';


### PR DESCRIPTION
The syntax highlighting overlay was causing scroll sync issues:
- Changed overlay overflow from 'auto' to 'hidden' to prevent
  independent scrolling
- Added immediate scroll position sync after innerHTML update
  to maintain scroll position when content changes