### PR TITLE
Restore cursor position after dismissing include modal

### DIFF
--- a/web-ui/src/Component/ClingoDemo.purs
+++ b/web-ui/src/Component/ClingoDemo.purs
@@ -1707,8 +1707,10 @@ handleAction = case _ of
     -- Navigate to the included file
     H.modify_ \s -> s { currentFile = targetPath, navigateIncludeTarget = Nothing }
 
-  CancelNavigateToInclude ->
+  CancelNavigateToInclude -> do
     H.modify_ \s -> s { navigateIncludeTarget = Nothing }
+    -- Refocus the textarea so cursor position is preserved
+    liftEffect $ TU.focusTextarea "editor-textarea"
 
   ShowTimingDiff entry ->
     H.modify_ \s -> s { selectedTimingEntry = Just entry }


### PR DESCRIPTION
When the user clicks an #include file link, a modal appears asking if
they want to navigate. After dismissing the modal (via Cancel or backdrop
click), the cursor was lost because focus moved away from the textarea.

Fix by calling focusTextarea after clearing the modal state, which
restores focus to the editor and preserves the original cursor position.