### PR TITLE
Fix ASP syntax errors: replace anonymous variables in term unification

### DIFF
--- a/roles/bmr/demons/shabaloth.lp
+++ b/roles/bmr/demons/shabaloth.lp
@@ -56,7 +56,7 @@ died(P, T) :- shabaloth_kill_succeeds(P, N), final_night_time(N, T), alive(P, ni
 shabaloth_killed_last_night(P, N) :-
     night_number(N), N > 2,
     shabaloth_target(_, P, _, N-1),
-    died(P, T), T = night(N-1, _, _).
+    died(P, T), time(T), T = night(N-1, R, S).
 
 % ST may choose to regurgitate one of last night's victims
 { shabaloth_regurgitates(P, N) : shabaloth_killed_last_night(P, N) } <= 1 :-
@@ -74,8 +74,8 @@ resurrected(P, N) :- shabaloth_regurgitates(P, N).
 
 alive(P, T) :-
     shabaloth_regurgitates(P, N),
-    time(T), T = night(M, _, _), M >= N.
+    time(T), T = night(M, R, S), M >= N.
 
 alive(P, T) :-
     shabaloth_regurgitates(P, N),
-    time(T), T = day(M, _), M >= N.
+    time(T), T = day(M, Phase), M >= N.

--- a/roles/bmr/minions/assassin.lp
+++ b/roles/bmr/minions/assassin.lp
@@ -47,4 +47,4 @@ dead(P, T) :- reminder_on(assassin_dead, P, T).
 died(P, T) :- assassin_kills(P, N), final_night_time(N, T), alive(P, night(N, 0, 0)).
 
 % Override Sailor protection for Assassin
-:- assassin_kills(P, N), protected_from_death(P, T), T = night(N, _, _), not died(P, T).
+:- assassin_kills(P, N), protected_from_death(P, T), time(T), T = night(N, R, S), not died(P, T).

--- a/roles/bmr/outsiders/goon.lp
+++ b/roles/bmr/outsiders/goon.lp
@@ -30,7 +30,7 @@ reminder_on(goon_drunk, Chooser, T) :-
     goon_drunk_active(N, T).
 
 goon_drunk_active(N, T) :-
-    time(T), T = night(N, _, _).
+    time(T), T = night(N, R, S).
 goon_drunk_active(N, dawn(N)) :- night_number(N).
 
 % Token removed at dusk (start of day)
@@ -57,8 +57,8 @@ goon_becomes_alignment(Goon, good, N) :-
 % Override registration for Goon after alignment change
 registers_as(Goon, evil, T) :-
     goon_becomes_alignment(Goon, evil, N),
-    time(T), T = night(M, _, _), M >= N.
+    time(T), T = night(M, R, S), M >= N.
 
 registers_as(Goon, evil, T) :-
     goon_becomes_alignment(Goon, evil, N),
-    time(T), T = day(M, _), M >= N.
+    time(T), T = day(M, Phase), M >= N.

--- a/roles/bmr/outsiders/moonchild.lp
+++ b/roles/bmr/outsiders/moonchild.lp
@@ -11,7 +11,7 @@ moonchild_died_tonight(MC, N) :-
     night_number(N), N > 1,
     alive(MC, night(N, 0, 0)),
     died(MC, T),
-    T = night(N, _, _).
+    time(T), T = night(N, R, S).
 
 % Moonchild died during the day (executed)
 moonchild_died_today(MC, N) :-

--- a/roles/bmr/townsfolk/professor.lp
+++ b/roles/bmr/townsfolk/professor.lp
@@ -53,12 +53,12 @@ resurrected(P, N) :- professor_resurrects(P, N).
 alive(P, T) :-
     resurrected(P, N),
     time(T),
-    T = night(M, _, _), M >= N.
+    T = night(M, R, S), M >= N.
 
 alive(P, T) :-
     resurrected(P, N),
     time(T),
-    T = day(M, _), M >= N.
+    T = day(M, Phase), M >= N.
 
 alive(P, T) :-
     resurrected(P, N),
@@ -67,4 +67,4 @@ alive(P, T) :-
 
 % Remove death state after resurrection
 % The player is no longer dead after being resurrected
-:- dead(P, T), resurrected(P, N), time(T), T = night(M, _, _), M > N.
+:- dead(P, T), resurrected(P, N), time(T), T = night(M, R, S), M > N.


### PR DESCRIPTION
In Clingo/ASP, anonymous variables (_) cannot be used in term unification
expressions like `T = night(N, _, _)`. Replace them with named variables
(R, S, Phase) that are grounded via time(T).

Fixed files:
- assassin.lp: constraint with protected_from_death
- shabaloth.lp: regurgitation logic and alive predicates
- moonchild.lp: moonchild_died_tonight detection
- goon.lp: drunk active periods and alignment registration
- professor.lp: resurrection alive predicates and constraint