### PR TITLE
Fix prepass including files from commented-out #include directives

### DIFF
--- a/web-ui/src/Clingo.js
+++ b/web-ui/src/Clingo.js
@@ -61,8 +61,11 @@ export const resolveIncludesWithPathImpl = (program) => (currentFilePath) => (fi
 
     const currentDir = getDirectory(filePath);
 
-    // Match #include "filename".
-    return content.replace(/#include\s+"([^"]+)"\s*\./g, (match, includePath) => {
+    // Match #include "filename" at the start of a line (with optional leading whitespace).
+    // Use multiline mode (m) so ^ matches start of each line.
+    // (\s*) matches only whitespace before #include, which naturally excludes
+    // commented-out includes (% is not whitespace) and malformed lines.
+    return content.replace(/^(\s*)#include\s+"([^"]+)"\s*\./gm, (match, prefix, includePath) => {
       // Try to resolve the path:
       // 1. First, try as-is (relative to working directory / root)
       // 2. If not found, try relative to the current file's directory


### PR DESCRIPTION
The regex in resolveIncludesWithPathImpl was matching #include
directives even when they appeared after a % comment character.
This caused files to be included even when the include was
commented out (e.g., "% #include \"bmr.lp\".").

Changed the regex to use multiline mode and require that only
whitespace (not arbitrary content) appears before #include.
This naturally excludes commented lines since % is not whitespace.