### PR TITLE
Add script metadata headers with name and id

### DIFF
--- a/bmr.lp
+++ b/bmr.lp
@@ -1,4 +1,5 @@
-% Bad Moon Rising Script
+% @script-name: Bad Moon Rising
+% @script-id: bmr
 
 #include "roles/bmr/base.lp".
 #include "roles/bmr/registration.lp".

--- a/snv.lp
+++ b/snv.lp
@@ -1,4 +1,5 @@
-% Sects & Violets Script
+% @script-name: Sects & Violets
+% @script-id: snv
 
 #include "roles/snv/base.lp".
 

--- a/tb.lp
+++ b/tb.lp
@@ -1,4 +1,5 @@
-% Trouble Brewing Script
+% @script-name: Trouble Brewing
+% @script-id: tb
 
 #include "roles/tb/base.lp".
 #include "roles/tb/registration.lp".


### PR DESCRIPTION
Each script file (tb.lp, bmr.lp, snv.lp) now has a parseable header:
- @script-name: Human-readable name (e.g., "Trouble Brewing")
- @script-id: Short identifier (e.g., "tb")

This enables future features like embedding script selection in URLs.