### PR TITLE
Add copy-to-clipboard buttons to output/error displays

### DIFF
--- a/web-ui/src/TextareaUtils.js
+++ b/web-ui/src/TextareaUtils.js
@@ -338,6 +338,45 @@ export const updateHighlightOverlayImpl = (textareaId) => (overlayId) => (code) 
   }
 };
 
+// Copy text to clipboard
+// Returns true if successful, false otherwise
+export const copyToClipboardImpl = (text) => () => {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).catch(err => {
+      console.error('Failed to copy to clipboard:', err);
+    });
+    return true;
+  } else {
+    // Fallback for older browsers
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      return true;
+    } catch (err) {
+      console.error('Fallback copy failed:', err);
+      document.body.removeChild(textarea);
+      return false;
+    }
+  }
+};
+
+// Copy text to clipboard and stop event propagation
+// Takes event and text, returns true if copy successful
+export const copyToClipboardWithEventImpl = (event) => (text) => () => {
+  // Stop the event from bubbling up (e.g., to prevent selecting the answer set)
+  if (event && event.stopPropagation) {
+    event.stopPropagation();
+  }
+  // Use the regular copy function
+  return copyToClipboardImpl(text)();
+};
+
 // Detect if the cursor is on an #include directive and return the file path
 // Returns null if not on an include, or the file path string if found
 export const getIncludeAtCursorImpl = (elementId) => () => {

--- a/web-ui/src/TextareaUtils.purs
+++ b/web-ui/src/TextareaUtils.purs
@@ -7,6 +7,8 @@ module TextareaUtils
   , highlightLP
   , syncScroll
   , updateHighlightOverlay
+  , copyToClipboard
+  , copyToClipboardWithEvent
   ) where
 
 import Prelude
@@ -14,6 +16,7 @@ import Prelude
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 import Effect (Effect)
+import Web.Event.Event (Event)
 
 -- | Scroll a textarea to a specific line and select/highlight it
 -- | Takes the element ID and line number (1-indexed)
@@ -72,3 +75,17 @@ foreign import updateHighlightOverlayImpl :: String -> String -> String -> Effec
 
 updateHighlightOverlay :: String -> String -> String -> Effect Unit
 updateHighlightOverlay = updateHighlightOverlayImpl
+
+-- | Copy text to the clipboard
+-- | Returns true if successful, false otherwise
+foreign import copyToClipboardImpl :: String -> Effect Boolean
+
+copyToClipboard :: String -> Effect Boolean
+copyToClipboard = copyToClipboardImpl
+
+-- | Copy text to the clipboard and stop event propagation
+-- | Useful when the copy button is inside a clickable container
+foreign import copyToClipboardWithEventImpl :: Event -> String -> Effect Boolean
+
+copyToClipboardWithEvent :: Event -> String -> Effect Boolean
+copyToClipboardWithEvent = copyToClipboardWithEventImpl


### PR DESCRIPTION
- Add copyToClipboard FFI function in TextareaUtils.js with fallback for older browsers
- Add copyToClipboardWithEvent variant that stops event propagation
- Add PureScript bindings in TextareaUtils.purs
- Add copy button with clipboard icon to error display in ClingoDemo.purs
- Add smaller copy button to each answer set item
- Copy button on answer sets uses event propagation stop to prevent triggering the answer set selection when clicking copy