### PR TITLE
Fix unsafe variables in courtier, minstrel, and goon rules

### DIFF
--- a/roles/bmr/outsiders/goon.lp
+++ b/roles/bmr/outsiders/goon.lp
@@ -19,6 +19,7 @@ goon_first_target(Goon, Chooser, N) :-
     not earlier_goon_target(Goon, N, RoleOrd).
 
 earlier_goon_target(Goon, N, RoleOrd) :-
+    goon_targeted_by(Goon, _, _, night(N, RoleOrd, _)),
     goon_targeted_by(Goon, _, _, night(N, EarlierOrd, _)),
     EarlierOrd < RoleOrd.
 

--- a/roles/bmr/townsfolk/courtier.lp
+++ b/roles/bmr/townsfolk/courtier.lp
@@ -69,8 +69,8 @@ reminder_on(courtier_drunk, P, T) :-
 
 % Drunk is active for 3 nights and 3 days after the choice
 % Night N (when chosen), Day N, Night N+1, Day N+1, Night N+2, Day N+2
-courtier_drunk_active(N, night(M, _, _)) :- night_number(N), night_number(M), M >= N, M <= N+2.
-courtier_drunk_active(N, day(M, _)) :- night_number(N), day_number(M), M >= N, M <= N+2.
+courtier_drunk_active(N, T) :- night_number(N), time(T), T = night(M, _, _), M >= N, M <= N+2.
+courtier_drunk_active(N, T) :- night_number(N), time(T), T = day(M, _), M >= N, M <= N+2.
 courtier_drunk_active(N, dawn(M)) :- night_number(N), day_number(M), M >= N, M <= N+2.
 
 causes_impairment(courtier_drunk).

--- a/roles/bmr/townsfolk/minstrel.lp
+++ b/roles/bmr/townsfolk/minstrel.lp
@@ -28,7 +28,7 @@ reminder_on(minstrel_drunk, P, T) :-
 
 % Drunk is active from execution until dusk next day
 minstrel_drunk_active(N, day(N, exec)) :- day_number(N).
-minstrel_drunk_active(N, night(N+1, _, _)) :- day_number(N), night_number(N+1).
+minstrel_drunk_active(N, T) :- day_number(N), time(T), T = night(M, _, _), M = N+1.
 minstrel_drunk_active(N, dawn(N+1)) :- day_number(N), day_number(N+1).
 
 % Token removed at dusk (start of day N+1, after dawn)


### PR DESCRIPTION
Use time(T) with unification pattern to ground variables in rule heads instead of anonymous variables which cause "unsafe variables" errors.

- courtier.lp: Ground night/day terms via time(T) unification
- minstrel.lp: Ground night term via time(T) unification
- goon.lp: Ground RoleOrd by requiring it from goon_targeted_by fact