### PR TITLE
Fix answer set filter to handle space-separated atoms

### DIFF
--- a/web-ui/src/Component/ClingoDemo/Render.purs
+++ b/web-ui/src/Component/ClingoDemo/Render.purs
@@ -537,9 +537,10 @@ renderResult state = case state.result of
     renderAnswerSet filterExpr selectedIdx idx atoms =
       let
         isSelected = idx == selectedIdx
-        -- Apply filter to atoms
+        -- Apply filter to atoms (handles space-separated atoms in array elements)
         filteredAtoms = FE.filterAtoms filterExpr atoms
-        totalAtomCount = length atoms
+        -- Count individual atoms (not lines) for accurate display
+        totalAtomCount = FE.countAtoms atoms
         filteredAtomCount = length filteredAtoms
         isFiltered = filterExpr /= "" && filteredAtomCount /= totalAtomCount
         atomsText = intercalate " " filteredAtoms

--- a/web-ui/src/FilterExpression.js
+++ b/web-ui/src/FilterExpression.js
@@ -253,9 +253,22 @@ export const compileFilterImpl = (expr) => {
 };
 
 // Filter an array of atoms using a filter expression
+// Handles both individual atoms and space-separated lines of atoms
 export const filterAtomsImpl = (expr, atoms) => {
   const matcher = compileFilterImpl(expr);
-  return atoms.filter(matcher);
+
+  // Flatten atoms: split any space-separated strings into individual atoms
+  const allAtoms = [];
+  for (const item of atoms) {
+    // Split by whitespace to handle lines containing multiple atoms
+    const parts = item.trim().split(/\s+/);
+    for (const part of parts) {
+      if (part) allAtoms.push(part);
+    }
+  }
+
+  // Filter individual atoms
+  return allAtoms.filter(matcher);
 };
 
 // Check if a filter expression is valid (returns error message or empty string)
@@ -275,4 +288,16 @@ export const validateFilterImpl = (expr) => {
 // Test if an atom matches a compiled filter function
 export const testFilterImpl = (filterFn, atom) => {
   return filterFn(atom);
+};
+
+// Count total individual atoms (handles space-separated atoms in array elements)
+export const countAtomsImpl = (atoms) => {
+  let count = 0;
+  for (const item of atoms) {
+    const parts = item.trim().split(/\s+/);
+    for (const part of parts) {
+      if (part) count++;
+    }
+  }
+  return count;
 };

--- a/web-ui/src/FilterExpression.purs
+++ b/web-ui/src/FilterExpression.purs
@@ -36,6 +36,9 @@ foreign import validateFilterImpl :: Fn1 String String
 -- | Test if an atom matches a compiled filter
 foreign import testFilterImpl :: Fn2 FilterFn String Boolean
 
+-- | Count total individual atoms (handles space-separated atoms in array elements)
+foreign import countAtomsImpl :: Fn1 (Array String) Int
+
 -- | Compile a filter expression into a reusable filter function
 compileFilter :: String -> FilterFn
 compileFilter = runFn1 compileFilterImpl
@@ -51,3 +54,7 @@ validateFilter = runFn1 validateFilterImpl
 -- | Check if filter expression is valid
 isValidFilter :: String -> Boolean
 isValidFilter expr = validateFilter expr == ""
+
+-- | Count total individual atoms (handles space-separated atoms in array elements)
+countAtoms :: Array String -> Int
+countAtoms = runFn1 countAtomsImpl


### PR DESCRIPTION
The filter was treating each array element as a single atom, but elements may contain multiple space-separated atoms. This caused the filter to:
- Match lines containing the search term anywhere
- Display all atoms from matching lines, not just matching atoms

Changes:
- filterAtomsImpl: Split array elements by whitespace before filtering
- countAtomsImpl: New function to count individual atoms after splitting
- ClingoDemo: Use countAtoms for accurate total atom count display

Now when filtering for "bag", only atoms containing "bag" are shown, not entire lines that happen to contain one "bag" atom.