### PR TITLE
Add bluff predicate and assert_bluff constraint for drag-drop

### DIFF
--- a/botc.lp
+++ b/botc.lp
@@ -400,6 +400,16 @@ distrib(R) :- assigned(0, _, R).
 :- assert_received(P, R), not received(P, R).
 % assert_drawn(R) requires that role R is in the bag (was drawn from script into bag)
 :- assert_drawn(R), not bag(R).
+
+% Bluffs: 3 good roles shown to the demon that are not in the bag
+% A role can be a bluff if it's a good role (townsfolk or outsider) and not in the bag
+can_be_bluff(R) :- townsfolk(R), not bag(R).
+can_be_bluff(R) :- outsider(R), not bag(R).
+% Choose exactly 3 bluffs from available candidates
+{bluff(R) : can_be_bluff(R)} = 3.
+% assert_bluff(R) requires that role R must be a bluff
+:- assert_bluff(R), not bluff(R).
+
 %{distrib(X) : demon(X)} = 1.
 %{distrib(X) : minion(X)} = 1    :- 7 <= player_count <= 9.
 %{distrib(X) : townsfolk(X)} = 5 - A :- 7 <= player_count <= 9, outsider_adjustment(A).

--- a/inst.lp
+++ b/inst.lp
@@ -45,6 +45,7 @@ needs_night(3).
 
 #show distrib/1.
 #show bag/1.
+#show bluff/1.
 %#show time/1.
 %#show next/2.
 %#show impaired/2.


### PR DESCRIPTION
The bluffs panel drag-drop was adding assert_bluff(role) statements
to inst.lp but the ASP solver had no corresponding rules:
- No bluff(R) predicate was defined
- No :- assert_bluff(R), not bluff(R). constraint existed
- No #show bluff/1. directive to expose results

Added to botc.lp:
- can_be_bluff(R) predicate for good roles (townsfolk/outsider) not in bag
- Choice rule to select exactly 3 bluffs from candidates
- assert_bluff constraint to enforce user-specified bluffs

Added to inst.lp:
- #show bluff/1. directive

This enables the bluffs panel to work in post-solve mode, not just
pre-solve mode (which used EarlyParser's direct conversion).