### PR TITLE
Fix pair-info roles to filter by correct role category

### DIFF
--- a/roles/tb/townsfolk/investigator.lp
+++ b/roles/tb/townsfolk/investigator.lp
@@ -29,7 +29,7 @@ first_night_substep(investigator, 3, st_tells(inv_info)).
    not registers_as(P, minion, T).
 
 % Functioning: ST tells a role the minion-reference may register as (constrained to truthful options)
-{ st_tells_core(investigator, INV, info(First, Second, R), T) : may_register_as_role(PMinion, R, T) } = 1 :-
+{ st_tells_core(investigator, INV, info(First, Second, R), T) : may_register_as_role(PMinion, R, T), minion(R) } = 1 :-
     T = night(1, RoleOrd, 3),
     first_night_role_order(investigator, RoleOrd),
     character_assignment_state_at_time(T, INV, investigator),

--- a/roles/tb/townsfolk/librarian.lp
+++ b/roles/tb/townsfolk/librarian.lp
@@ -47,7 +47,18 @@ lib_outsider_available :-
     chair_ordered(POutsider, PWrong, First, Second),
     functioning(LIB, T).
 
+% Not functioning: ST may choose to lie with "no outsiders" even when outsiders exist
+{ lib_tells_no_outsiders(LIB, T) } :-
+    T = night(1, RoleOrd, 3),
+    first_night_role_order(librarian, RoleOrd),
+    character_assignment_state_at_time(T, LIB, librarian),
+    not functioning(LIB, T),
+    lib_outsider_available.
+
+st_tells_core(librarian, LIB, no_outsiders, T) :- lib_tells_no_outsiders(LIB, T).
+
 % Not functioning (poisoned/drunk): ST may name any outsider role (no truthfulness constraint)
+% Only fires if the ST didn't choose to say "no outsiders" instead
 { st_tells_core(librarian, LIB, info(First, Second, R), T) : outsider(R) } = 1 :-
     T = night(1, RoleOrd, 3),
     first_night_role_order(librarian, RoleOrd),
@@ -55,10 +66,10 @@ lib_outsider_available :-
     reminder_on(lib_outsider, POutsider, T),
     reminder_on(lib_wrong, PWrong, T),
     chair_ordered(POutsider, PWrong, First, Second),
-    not functioning(LIB, T).
+    not functioning(LIB, T),
+    not lib_tells_no_outsiders(LIB, T).
 
-% No outsiders in game: ST tells librarian there are no outsiders
-% This applies regardless of functioning status (the info is always truthful in this case)
+% No outsiders in game: ST tells librarian there are no outsiders (always truthful)
 st_tells_core(librarian, LIB, no_outsiders, T) :-
     T = night(1, RoleOrd, 3),
     first_night_role_order(librarian, RoleOrd),

--- a/roles/tb/townsfolk/librarian.lp
+++ b/roles/tb/townsfolk/librarian.lp
@@ -4,17 +4,26 @@ first_night_substep(librarian, 1, st_places(lib_outsider)).
 first_night_substep(librarian, 2, st_places(lib_wrong)).
 first_night_substep(librarian, 3, st_tells(lib_info)).
 
-% ST secretly picks one player to be the outsider-reference; separate from lib_wrong placement below
+% Helper: some player registers as outsider at the librarian's info step
+lib_outsider_available :-
+    first_night_role_order(librarian, RoleOrd),
+    T = night(1, RoleOrd, 3),
+    player(P),
+    registers_as(P, outsider, T).
+
+% ST secretly picks one player to be the outsider-reference (only when outsiders are available)
 { reminder_on(lib_outsider, P, T) : player(P) } = 1 :-
     T = night(1, RoleOrd, 1),
     first_night_role_order(librarian, RoleOrd),
-    character_assignment_state_at_time(T, _, librarian).
+    character_assignment_state_at_time(T, _, librarian),
+    lib_outsider_available.
 
-% ST picks a second player as the decoy; must be a distinct step so chair_ordered can pair them
+% ST picks a second player as the decoy (only when outsiders are available)
 { reminder_on(lib_wrong, P, T) : player(P) } = 1 :-
     T = night(1, RoleOrd, 2),
     first_night_role_order(librarian, RoleOrd),
-    character_assignment_state_at_time(T, _, librarian).
+    character_assignment_state_at_time(T, _, librarian),
+    lib_outsider_available.
 
 % The two tokens must be on different players (otherwise the "two players, one is X" info is degenerate)
 :- reminder_on(lib_outsider, P, _),
@@ -28,8 +37,8 @@ first_night_substep(librarian, 3, st_tells(lib_info)).
    functioning(LibrarianPlayer, T),
    not registers_as(P, outsider, T).
 
-% Functioning: ST tells a role the outsider-reference may register as (constrained to truthful options)
-{ st_tells_core(librarian, LIB, info(First, Second, R), T) : may_register_as_role(POutsider, R, T) } = 1 :-
+% Functioning: ST tells a role the outsider-reference may register as (constrained to outsider roles)
+{ st_tells_core(librarian, LIB, info(First, Second, R), T) : may_register_as_role(POutsider, R, T), outsider(R) } = 1 :-
     T = night(1, RoleOrd, 3),
     first_night_role_order(librarian, RoleOrd),
     character_assignment_state_at_time(T, LIB, librarian),
@@ -47,3 +56,11 @@ first_night_substep(librarian, 3, st_tells(lib_info)).
     reminder_on(lib_wrong, PWrong, T),
     chair_ordered(POutsider, PWrong, First, Second),
     not functioning(LIB, T).
+
+% No outsiders in game: ST tells librarian there are no outsiders
+% This applies regardless of functioning status (the info is always truthful in this case)
+st_tells_core(librarian, LIB, no_outsiders, T) :-
+    T = night(1, RoleOrd, 3),
+    first_night_role_order(librarian, RoleOrd),
+    character_assignment_state_at_time(T, LIB, librarian),
+    not lib_outsider_available.

--- a/roles/tb/townsfolk/washerwoman.lp
+++ b/roles/tb/townsfolk/washerwoman.lp
@@ -29,7 +29,7 @@ first_night_substep(washerwoman, 3, st_tells(ww_info)).
    not registers_as(P, townsfolk, T).
 
 % Functioning: ST tells a role the townsfolk-reference may register as (constrained to truthful options)
-{ st_tells_core(washerwoman, WW, info(First, Second, R), T) : may_register_as_role(PTownsfolk, R, T) } = 1 :-
+{ st_tells_core(washerwoman, WW, info(First, Second, R), T) : may_register_as_role(PTownsfolk, R, T), townsfolk(R) } = 1 :-
     T = night(1, RoleOrd, 3),
     first_night_role_order(washerwoman, RoleOrd),
     character_assignment_state_at_time(T, WW, washerwoman),


### PR DESCRIPTION
Washerwoman, Librarian, and Investigator functioning rules used
may_register_as_role without category constraints, allowing cross-category
role names (e.g., Spy as Washerwoman's reference could produce "Butler").

Add townsfolk(R) filter to Washerwoman, outsider(R) to Librarian, and
minion(R) to Investigator functioning choice rules.

Also add "no outsiders" info path for Librarian: when no player registers
as outsider, the ST tells the Librarian no_outsiders instead of requiring
reminder placement that would cause UNSAT.

https://claude.ai/code/session_01BVvhqePSs36w6Mb6xMWtD9