### PR TITLE
Add cross-validation harness for botc-zdd- distribution counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ web-ui/src/BuildInfo.js
 engine/__pycache__/
 engine-ts/node_modules/
 engine-ts/dist/
+cross-validation/oracle_counts.json
 *.pyc
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file contains instructions for Claude Code when working on this repository.
 
+## Related Repositories
+
+This repo (`pnkfelix/botc-asp`) has a companion repo **`pnkfelix/botc-zdd-`** (TypeScript, ZDD-based BotC modeling). When the user references PRs, issues, or code in `botc-zdd-`, use that repo for GitHub API calls:
+
+```
+https://api.github.com/repos/pnkfelix/botc-zdd-/...
+```
+
+The `botc-zdd-` repo contains the ZDD game engine (TypeScript/Vitest) that models BotC mechanics using Zero-suppressed Decision Diagrams. Work on "Prompt 4", "Night 2 actions", "Monk/Imp/starpass", etc. refers to `botc-zdd-`.
+
 ## Environment Differences
 
 Claude Code runs in two environments with different capabilities:

--- a/ZDD_INTEGRATION_PLAN.md
+++ b/ZDD_INTEGRATION_PLAN.md
@@ -52,22 +52,76 @@ variables.
 
 ## Prompt 3: Spy/Recluse registration + Fortune Teller red herring
 
-**Status: Not started**
+**Status: Merged (PRs #6, #8). Cross-validation switched to ASP oracle.**
 
 These modify what counts as "truthful" for info roles. Spy can appear as good to
 info roles, Recluse can appear as evil. Fortune Teller has a pre-designated red
 herring player. All three expand the set of valid ST info choices without changing
 the phase architecture.
 
+Key changes:
+- Spy registers as any Townsfolk/Outsider for info role purposes
+- Recluse registers as any Minion/Demon for info role purposes
+- Fortune Teller red herring: one non-Demon player designated to trigger "Yes"
+- FT pair choice variables added (which two players the FT chooses to read)
+- PR #8 fix: Spy/Recluse cannot register as their own type, and Librarian
+  correctly handles optional "No Outsiders" branch
+
+After this prompt landed, the Python oracle in `validate_night_info.py` was
+replaced with the real clingo ASP oracle — two fully independent implementations
+now cross-validate against each other. All 11 scenarios pass.
+
 ---
 
-## Prompt 4: Active night roles + death
+## Prompt 4: Night 2 active roles + death
 
-**Status: Not started**
+**Status: Merged (PRs #9, #10). Cross-validation passing.**
 
-Imp demon kill (not Night 1), Monk protection, Soldier immunity. These add
-variables to later night phases and introduce the concept of players dying between
-nights, which affects Empath neighbor calculations and game progression.
+Adds Night 2 action phase as a new ZDD phase type (`NightAction`), separate from
+Night 1 info (`NightInfo`). Introduces:
+
+- **Poisoner N2 retarget**: Poisoner picks a new target for Night 2
+- **Monk protection**: Monk chooses one player to protect from demon kill
+- **Imp kill**: Imp chooses a target; kill resolves considering Monk protection
+- **Imp starpass**: Imp can self-target if living minions exist, passing demon
+  status to a minion (recipient choice is a ZDD variable)
+- **Soldier immunity**: Soldier is immune to demon kill (functioning only)
+- **Empath N2**: Re-queries after death, skipping dead neighbors
+- **Fortune Teller N2**: Re-queries after death, checking for new demon after
+  starpass
+
+Architecture: cascading branches — each Poisoner target creates a malfunctioning
+context, each Monk target creates a protection context, each Imp target resolves
+kill/no-kill, then info roles build on top. Branches combined via union.
+
+PR #10 fix: Fortune Teller correctly detects starpass (demon changed) and Soldier
+immunity prevents kill when functioning (not poisoned).
+
+---
+
+## Prompt 6: Day phase + Undertaker + dead seat handling
+
+**Status: Merged (PR #11). Cross-validation passing.**
+
+Adds Day phase support to the Game class and implements Undertaker as the first
+Night 2 info role that depends on Day phase state.
+
+Key changes:
+- **`DayResult` type**: Records execution (seat, role), other deaths, cumulative
+  dead set
+- **`recordDay()` method**: State transition with zero ZDD variables (root = TOP),
+  validates alive, snapshots for undo
+- **`recordNightDeath()` method**: Records observed night deaths without creating
+  a new phase
+- **Dead seat handling**: Dead actors skipped (Poisoner, Monk, Imp), dead seats
+  excluded from targets, dead minions excluded from starpass, Empath/FT skip
+  pre-dead neighbors
+- **Undertaker**: Learns executed player's role; one variable per role in
+  selected set; functioning → exact role, malfunctioning → any role; inactive
+  when dead or no execution
+- **Undo support**: Restores dead set from snapshot, pops day results
+
+Test coverage: 20 tests (17 specified + 3 integration).
 
 ---
 
@@ -80,48 +134,55 @@ same inputs the botc-asp web app works with and produces comparable outputs.
 Verify browser bundleability. Maybe a small cross-validation script like we have
 for distributions.
 
+Now that we have the full Night 1 → Day 1 → Night 2 pipeline with Undertaker,
+integration can demonstrate multi-phase gameplay. Potential scope:
+
+- Browser bundle verification (ZDD + game engine in WASM-free JS)
+- Shadow mode: run ZDD engine alongside ASP engine in the web UI, compare outputs
+- Night 2 cross-validation script (extend `validate_night_info.py` pattern to
+  cover Night 2 action scenarios)
+- API surface cleanup: ensure Game class methods have a clean, documented interface
+
 ---
 
 ## Integration Milestones
 
-- **Prompts 1-3**: Minimum for useful integration (info roles with full TB complexity)
-- **Prompt 3 specifically**: Enables switching cross-validation to the real ASP oracle (see below)
-- **Prompt 4**: Enables multi-night games
-- **Prompt 5**: Bridge back to this repo
+- **Prompts 1-3**: Minimum for useful integration (info roles with full TB complexity) — **DONE**
+- **Prompt 3 specifically**: Enables switching cross-validation to the real ASP oracle — **DONE**
+- **Prompt 4**: Enables multi-night games — **DONE**
+- **Prompt 6**: Day phase + Undertaker, completing the Night 1 → Day 1 → Night 2 loop — **DONE**
+- **Prompt 5**: Bridge back to this repo — **NEXT**
 
 ---
 
 ## Cross-Validation Strategy
 
-### Current state (Prompts 1-2)
+### Current state (Prompts 1-4, 6 complete)
 
-The night info cross-validation (`cross-validation/validate_night_info.py`) uses
-a **Python oracle** that independently computes expected world counts. This is
-NOT ideal — it reimplements the same spec as the ZDD, so shared misunderstandings
-of the spec would not be caught. We use it because the ZDD doesn't yet model
-Spy/Recluse registration or Fortune Teller, so running clingo against the full
-botc-asp rules would produce different (larger) answer set counts.
+Cross-validation uses the **real clingo ASP oracle** for Night 1 info. The Python
+oracle was retired after Prompt 3 landed. Two independent implementations (ASP
+declarative rules vs ZDD procedural builder) are compared by output count.
 
-Distribution cross-validation already uses the real clingo oracle and passes.
+**Night 1 info** (`cross-validation/validate_night_info.py`):
+- 11 scenarios covering 5p–7p games with Poisoner, Spy, Recluse, Fortune Teller
+- All pass: ASP projected model count == ZDD world count
+- ZDD is 130x–8,000x faster than clingo across all scenarios
 
-### Target state (after Prompt 3)
+**Distributions** (`cross-validation/validate_distributions.py`):
+- 12 scenarios (5p–10p, with/without Baron)
+- All pass
 
-Once Prompt 3 lands (Spy/Recluse registration + Fortune Teller red herring), the
-ZDD's modeling scope for Night 1 info will match what the botc-asp ASP rules
-encode. At that point, **replace the Python oracle with clingo enumeration
-against the real ASP rules**:
+**Benchmarks** (`cross-validation/benchmark_night_info.py`):
+- ZDD: sub-2ms per scenario, 5 MB heap, max 510 nodes
+- ASP: 250ms–5s per scenario, 70 MB peak RSS
+- Largest scenario (7p Spy+info, 34,020 worlds): 0.6ms ZDD vs 5.0s ASP
 
-1. Feed clingo the concrete seat assignment + `botc.lp` + `tb.lp` + role files
-2. Enumerate all valid `st_tells_core` answer sets (including poisoner target,
-   malfunctioning outputs, Spy/Recluse registration, FT red herring)
-3. Count answer sets and compare against ZDD world count
+### Future: Night 2 cross-validation
 
-This is the real validation — two independent implementations (ASP declarative
-rules vs ZDD procedural builder) of the same game logic, compared by output.
-Any disagreement reveals a genuine bug in one or the other.
-
-**Priority: Switch to the ASP oracle as soon as Prompt 3 merges.** The Python
-oracle is a stopgap. Do not let it persist beyond Prompt 3.
+Night 2 action phase cross-validation is not yet implemented. This would require
+extending the ASP oracle to model Night 2 actions (Poisoner retarget, Monk
+protection, Imp kill, Empath/FT re-query, Undertaker) and comparing against the
+ZDD `buildNightActionZDD` output. This is a natural Prompt 5 task.
 
 ---
 
@@ -175,3 +236,84 @@ The implementation correctly addresses all Prompt 2 requirements:
 2. Chef maximal variable count is `numPlayers + 1` whether functioning or not.
    No variable count mismatch.
 3. CI passes.
+
+### PR #6 Review (2026-03-12)
+
+**Verdict: Approve — Prompt 3 complete**
+
+Adds Spy/Recluse registration and Fortune Teller with red herring (+1,485 -373
+across 5 files). Major rework of the night info builder:
+
+- Spy registers as any Townsfolk/Outsider; Recluse as any Minion/Demon
+- Fortune Teller: red herring seat config, FT pair choice variables, "Yes"/"No"
+  output based on whether either chosen player is Demon (or red herring)
+- Comprehensive test suite covering Spy/Recluse/FT interactions
+- Cross-validated against clingo ASP oracle: all scenarios pass
+
+### PR #8 Review (2026-03-12)
+
+**Verdict: Approve — Prompt 3 bugfix**
+
+Fixes two issues found during cross-validation (+77 -17 across 3 files):
+
+1. Spy cannot register as Minion/Demon (own type), Recluse cannot register as
+   Townsfolk/Outsider (own type) — this was producing extra worlds
+2. Librarian correctly handles "No Outsiders" output as an optional branch when
+   no Outsiders are in the game
+
+After this fix, all 11 cross-validation scenarios pass against the ASP oracle.
+
+### PR #9 Review (2026-03-12)
+
+**Verdict: Approve — Prompt 4 complete**
+
+Adds Night 2 action phase (+1,748 lines, 4 new files). Entirely new module
+`night-action.ts` with cascading branch architecture:
+
+- Variables: PoisonerN2 targets, MonkTarget, ImpTarget, StarpassRecipient,
+  EmpathN2, FortuneTellerN2
+- Kill resolution: Imp target dies unless Monk-protected or Soldier (functioning)
+- Starpass: Imp self-targets → dies, demon status passes to living minion
+- Empath/FT re-query after death with updated neighbor/demon state
+- 37 tests covering all role interactions and branch counts
+
+### PR #10 Review (2026-03-12)
+
+**Verdict: Approve — Prompt 4 bugfix**
+
+Fixes two issues (+299 -13 across 2 files):
+
+1. Fortune Teller starpass detection: FT now correctly identifies the new demon
+   seat after starpass (was using original demon seat)
+2. Soldier immunity: Soldier is immune to demon kill when functioning (not
+   poisoned by Night 2 Poisoner target)
+
+### PR #11 Review (2026-03-12)
+
+**Verdict: Approve — Prompt 6 (Day phase + Undertaker)**
+
+Adds Day phase support and Undertaker role (+896 -31 across 4 files):
+
+**Day phase (Game class):**
+- `DayResult` interface: dayNumber, executedSeat/Role, otherDeaths, deadSeats
+- `recordDay()`: zero ZDD variables (root = TOP), validates alive, snapshots for undo
+- `recordNightDeath()`: state update without new phase
+- Undo restores dead set from snapshot
+
+**Dead seat handling (night-action.ts):**
+- Dead Poisoner/Monk/Imp skipped (no variables generated)
+- Dead seats excluded from all target lists
+- Dead minions excluded from starpass eligibility
+- Empath/FT skip pre-dead seats in neighbor calculations
+
+**Undertaker:**
+- One variable per role in selectedRoles
+- Active only when alive AND execution occurred
+- Functioning: exactly the executed role; malfunctioning: any role
+- Integrated into `buildInfoRolesForBranch` via `zdd.product`
+
+**Tests:** 20 tests (5 Day phase, 5 dead seats, 5 Undertaker, 2 branch counts,
+3 Game class integration). All pass.
+
+**Cross-validation:** All 11 Night 1 info scenarios and 12 distribution scenarios
+continue to pass. ZDD performance unchanged (sub-2ms, 5 MB heap).

--- a/ZDD_INTEGRATION_PLAN.md
+++ b/ZDD_INTEGRATION_PLAN.md
@@ -1,92 +1,93 @@
 # botc-zdd- Integration Plan
 
-This document captures the multi-prompt plan for building the `botc-zdd-` library
-(a dependency of botc-asp) and reviewing its PRs to ensure they match our integration
-expectations.
+This document tracks the incremental development of the `botc-zdd-` library
+and its integration into botc-asp. Each "Prompt" maps to one or more PRs on
+botc-zdd- that we review before merging, then test integration with our ASP code.
 
-## Overview
+## Key Architectural Insight
 
-The botc-zdd- library provides ZDD-based (Zero-suppressed Decision Diagram) world tracking
-for Blood on the Clocktower game state. It encodes role distributions, seat assignments,
-and night information as ZDD phases, allowing efficient enumeration and constraint propagation.
-
-We (botc-asp) will eventually integrate this library to provide a web-based BotC solver
-alongside our existing ASP-based approach.
+The ZDD phases are **not** one giant cross-product of all possibilities. Each
+phase commits to concrete choices from the previous phase, then the ZDD
+represents uncertainty only about the current phase's decisions. This mirrors
+actual gameplay — there's one true game state, and the tool helps explore
+what's consistent with observations.
 
 ---
 
-## Prompt 1: Phase-Chain Architecture + Night 1 Info Roles (PRs #2, #3, #4)
+## Prompt 1: Night 1 Information Roles (all functioning)
 
-**Status: Merged**
+**Status: Merged (PRs #2, #3, #4)**
 
-Established the core architecture:
-- ZDD class with union, product, require, offset, count, enumerate operations
+Takes a concrete seat assignment. Builds a ZDD of valid ST information choices
+for Washerwoman, Librarian, Investigator, Chef, Empath. Chef and Empath are
+fully determined by the seating (single valid output). Washerwoman/Librarian/
+Investigator have ST choice (which pair to show), so the ZDD represents those
+choices.
+
+Established:
+- ZDD class with union, product, require, offset, count, enumerate
 - Phase chain: Distribution -> SeatAssignment -> NightInfo
 - Game class managing phase transitions
-- Night 1 info roles: Washerwoman, Librarian, Investigator, Chef, Empath
 - Variable encoding: each info output gets a unique variable ID
-- exactlyOne ZDD constraint for each info role's valid outputs
+- exactlyOne ZDD constraint per info role
 - Cross-product of independent info roles
 - Lookup helpers: findPairInfoVariable, findCountInfoVariable
 - Observation system: require-variable, exclude-variable
 
 ---
 
-## Prompt 2: Poisoner Target Selection and Malfunctioning Info Roles (PR #5)
+## Prompt 2: Poisoner + Drunk (malfunctioning info)
 
-**Status: Open (CI passing)**
+**Status: PR #5 open, CI passing**
 **Branch: claude/add-poisoner-malfunctioning-roles-bDI3I**
 
-### Requirements
-
-1. **Architecture fix**: Malfunctioning info roles must generate the SAME variables as
-   functioning ones, but allow ANY valid output (not just truthful). Previously they
-   returned emptyResult() with zero variables.
-
-2. **Poisoner target selection**: When Poisoner is in play, add N-1 target variables
-   (one per non-Poisoner seat) with exactlyOne constraint. Variables come first (lower IDs),
-   then info role variables follow. All in the same ZDD phase.
-
-3. **Branching structure**: The valid info outputs DEPEND on which seat is poisoned, so
-   this is NOT a simple cross-product. Build separate ZDD branches per poisoner target,
-   then union them together.
-
-4. **Drunk handling**: Respect `malfunctioningSeats` set (caller provides it). A seat in
-   this set is always malfunctioning regardless of poisoner target.
-
-5. **New types**: PoisonerTargetOutput, findPoisonerTargetVariable helper.
-
-6. **Tests**: Poisoner targeting each role type, branch counts, observation forcing
-   poisoner target, Drunk always-malfunctioning, combined Drunk+Poisoner.
-
-### What NOT to do
-- No Spy, Recluse, Fortune Teller
-- No demon kill or death
-- No distribution/seat assignment changes
-- No Game class API changes beyond malfunctioningSeats parameter
+The poisoner's target choice is part of the Night 1 phase — it happens before
+info roles act. This expands the Night 1 ZDD: for each poisoner target choice,
+the targeted info role (if any) gets unconstrained outputs while others stay
+truthful. Drunk is simpler — the Drunk's seat is known from the concrete
+assignment, so they're just always malfunctioning. This prompt revises the night
+phase builder from Prompt 1, adding poisoner target variables before info output
+variables.
 
 ---
 
-## Prompt 3: Fortune Teller + Undertaker (Future)
+## Prompt 3: Spy/Recluse registration + Fortune Teller red herring
 
-Night 1 and recurring night info roles. Fortune Teller has a "red herring" (a good
-player who registers as the Demon to the FT). Undertaker learns the role of the
-executed player on the previous day.
+**Status: Not started**
 
----
-
-## Prompt 4: Day Phase + Nominations + Execution (Future)
-
-Model the day phase: nominations, voting, execution. Track alive/dead state.
-Support the Slayer's day action.
+These modify what counts as "truthful" for info roles. Spy can appear as good to
+info roles, Recluse can appear as evil. Fortune Teller has a pre-designated red
+herring player. All three expand the set of valid ST info choices without changing
+the phase architecture.
 
 ---
 
-## Prompt 5: Demon Kill + Night Order (Future)
+## Prompt 4: Active night roles + death
 
-Model the Imp's night kill. Handle the full night order: Poisoner -> info roles ->
-Imp kill. Track death and its effect on subsequent night info (Empath's living
-neighbors change).
+**Status: Not started**
+
+Imp demon kill (not Night 1), Monk protection, Soldier immunity. These add
+variables to later night phases and introduce the concept of players dying between
+nights, which affects Empath neighbor calculations and game progression.
+
+---
+
+## Prompt 5: Integration readiness
+
+**Status: Not started**
+
+Clean API surface. Probably a high-level "shadow mode" function that takes the
+same inputs the botc-asp web app works with and produces comparable outputs.
+Verify browser bundleability. Maybe a small cross-validation script like we have
+for distributions.
+
+---
+
+## Integration Milestones
+
+- **Prompts 1-3**: Minimum for useful integration (info roles with full TB complexity)
+- **Prompt 4**: Enables multi-night games
+- **Prompt 5**: Bridge back to this repo
 
 ---
 
@@ -96,50 +97,47 @@ neighbors change).
 
 **Verdict: Approve with minor notes**
 
-The implementation correctly addresses all requirements from Prompt 2:
+The implementation correctly addresses all Prompt 2 requirements:
 
 **Architecture (correct):**
 - Malfunctioning roles now generate the same variable IDs as functioning ones
-- Uses a "maximal variable set" strategy: build with all seats malfunctioning to get
-  the superset of variables, then constrain per-branch
-- `buildAllInfoRolesConstrained` + `buildFunctioningRoleConstrained` filter truthful
-  variables from the maximal set
+- Uses a "maximal variable set" strategy: build with all seats malfunctioning to
+  get the superset of variables, then constrain per-branch
+- `buildAllInfoRolesConstrained` + `buildFunctioningRoleConstrained` filter
+  truthful variables from the maximal set
 
 **Poisoner variables (correct):**
-- N-1 target variables allocated at IDs 0..N-2
-- Info role variables start at ID N-1 (after poisoner vars)
-- exactlyOne constraint on poisoner targets (implicit via singleSet per branch + union)
+- N-1 target variables at IDs 0..N-2
+- Info role variables start after poisoner vars
+- exactlyOne on poisoner targets (implicit via singleSet per branch + union)
 
 **Branching (correct):**
 - Each poisoner target gets its own info-role ZDD
-- Per branch: target seat added to malfunctioningSeats -> that role unconstrained
+- Per branch: target seat added to malfunctioningSeats -> role unconstrained
 - Branches combined via union, not cross-product
 
 **Drunk/malfunctioningSeats (correct):**
 - `baseMalfunctioning` from config flows into every branch
-- A seat in baseMalfunctioning is always unconstrained, even when poisoner targets elsewhere
+- A seat in baseMalfunctioning is always unconstrained regardless of poisoner target
 
 **Variable consistency across branches (correct):**
 - All branches share the same variable IDs from the maximal result
-- The `pairOutputs`/`countOutputs` maps in the final result are from the maximal build (superset)
+- `pairOutputs`/`countOutputs` maps from the maximal build (superset)
 
 **Test coverage (comprehensive):**
-- All no-Poisoner tests updated to use Spy (avoids triggering Poisoner logic)
+- No-Poisoner tests updated to use Spy (avoids triggering Poisoner logic)
 - Per-branch count verification: 78 + 36 + 18 + 6 = 138
 - Observation forcing poisoner target (require count=0 -> must target Chef)
 - WW output only valid when malfunctioning -> forces poisoner on WW seat
 - Drunk always unconstrained regardless of poisoner target
 - Combined Drunk+Poisoner: 234 + 108 + 18 + 18 = 378
-- Game class integration tests with malfunctioningSeats pass-through
+- Game class integration with malfunctioningSeats pass-through
 - End-to-end pipeline with Poisoner
 
 **Minor notes (non-blocking):**
-1. The "No Outsiders" variable identification in `buildFunctioningRoleConstrained` (line 792)
-   relies on it being the only variable without a pairOutputs entry. This works because
-   `buildMalfunctioningPairRoleInfo` creates the "No Outsiders" var first (before pair vars)
-   and doesn't add it to pairOutputs. Fragile but correct for now.
-
-2. The Chef's maximal variable count is `numPlayers + 1` (counts 0..numPlayers), which is
-   the same whether functioning or malfunctioning. Good - no variable count mismatch.
-
-3. CI passes on this branch.
+1. "No Outsiders" variable identification in `buildFunctioningRoleConstrained`
+   relies on it being the only variable without a pairOutputs entry. Fragile
+   but correct for now.
+2. Chef maximal variable count is `numPlayers + 1` whether functioning or not.
+   No variable count mismatch.
+3. CI passes.

--- a/ZDD_INTEGRATION_PLAN.md
+++ b/ZDD_INTEGRATION_PLAN.md
@@ -1,0 +1,145 @@
+# botc-zdd- Integration Plan
+
+This document captures the multi-prompt plan for building the `botc-zdd-` library
+(a dependency of botc-asp) and reviewing its PRs to ensure they match our integration
+expectations.
+
+## Overview
+
+The botc-zdd- library provides ZDD-based (Zero-suppressed Decision Diagram) world tracking
+for Blood on the Clocktower game state. It encodes role distributions, seat assignments,
+and night information as ZDD phases, allowing efficient enumeration and constraint propagation.
+
+We (botc-asp) will eventually integrate this library to provide a web-based BotC solver
+alongside our existing ASP-based approach.
+
+---
+
+## Prompt 1: Phase-Chain Architecture + Night 1 Info Roles (PRs #2, #3, #4)
+
+**Status: Merged**
+
+Established the core architecture:
+- ZDD class with union, product, require, offset, count, enumerate operations
+- Phase chain: Distribution -> SeatAssignment -> NightInfo
+- Game class managing phase transitions
+- Night 1 info roles: Washerwoman, Librarian, Investigator, Chef, Empath
+- Variable encoding: each info output gets a unique variable ID
+- exactlyOne ZDD constraint for each info role's valid outputs
+- Cross-product of independent info roles
+- Lookup helpers: findPairInfoVariable, findCountInfoVariable
+- Observation system: require-variable, exclude-variable
+
+---
+
+## Prompt 2: Poisoner Target Selection and Malfunctioning Info Roles (PR #5)
+
+**Status: Open (CI passing)**
+**Branch: claude/add-poisoner-malfunctioning-roles-bDI3I**
+
+### Requirements
+
+1. **Architecture fix**: Malfunctioning info roles must generate the SAME variables as
+   functioning ones, but allow ANY valid output (not just truthful). Previously they
+   returned emptyResult() with zero variables.
+
+2. **Poisoner target selection**: When Poisoner is in play, add N-1 target variables
+   (one per non-Poisoner seat) with exactlyOne constraint. Variables come first (lower IDs),
+   then info role variables follow. All in the same ZDD phase.
+
+3. **Branching structure**: The valid info outputs DEPEND on which seat is poisoned, so
+   this is NOT a simple cross-product. Build separate ZDD branches per poisoner target,
+   then union them together.
+
+4. **Drunk handling**: Respect `malfunctioningSeats` set (caller provides it). A seat in
+   this set is always malfunctioning regardless of poisoner target.
+
+5. **New types**: PoisonerTargetOutput, findPoisonerTargetVariable helper.
+
+6. **Tests**: Poisoner targeting each role type, branch counts, observation forcing
+   poisoner target, Drunk always-malfunctioning, combined Drunk+Poisoner.
+
+### What NOT to do
+- No Spy, Recluse, Fortune Teller
+- No demon kill or death
+- No distribution/seat assignment changes
+- No Game class API changes beyond malfunctioningSeats parameter
+
+---
+
+## Prompt 3: Fortune Teller + Undertaker (Future)
+
+Night 1 and recurring night info roles. Fortune Teller has a "red herring" (a good
+player who registers as the Demon to the FT). Undertaker learns the role of the
+executed player on the previous day.
+
+---
+
+## Prompt 4: Day Phase + Nominations + Execution (Future)
+
+Model the day phase: nominations, voting, execution. Track alive/dead state.
+Support the Slayer's day action.
+
+---
+
+## Prompt 5: Demon Kill + Night Order (Future)
+
+Model the Imp's night kill. Handle the full night order: Poisoner -> info roles ->
+Imp kill. Track death and its effect on subsequent night info (Empath's living
+neighbors change).
+
+---
+
+## PR Review Log
+
+### PR #5 Review (2026-03-12)
+
+**Verdict: Approve with minor notes**
+
+The implementation correctly addresses all requirements from Prompt 2:
+
+**Architecture (correct):**
+- Malfunctioning roles now generate the same variable IDs as functioning ones
+- Uses a "maximal variable set" strategy: build with all seats malfunctioning to get
+  the superset of variables, then constrain per-branch
+- `buildAllInfoRolesConstrained` + `buildFunctioningRoleConstrained` filter truthful
+  variables from the maximal set
+
+**Poisoner variables (correct):**
+- N-1 target variables allocated at IDs 0..N-2
+- Info role variables start at ID N-1 (after poisoner vars)
+- exactlyOne constraint on poisoner targets (implicit via singleSet per branch + union)
+
+**Branching (correct):**
+- Each poisoner target gets its own info-role ZDD
+- Per branch: target seat added to malfunctioningSeats -> that role unconstrained
+- Branches combined via union, not cross-product
+
+**Drunk/malfunctioningSeats (correct):**
+- `baseMalfunctioning` from config flows into every branch
+- A seat in baseMalfunctioning is always unconstrained, even when poisoner targets elsewhere
+
+**Variable consistency across branches (correct):**
+- All branches share the same variable IDs from the maximal result
+- The `pairOutputs`/`countOutputs` maps in the final result are from the maximal build (superset)
+
+**Test coverage (comprehensive):**
+- All no-Poisoner tests updated to use Spy (avoids triggering Poisoner logic)
+- Per-branch count verification: 78 + 36 + 18 + 6 = 138
+- Observation forcing poisoner target (require count=0 -> must target Chef)
+- WW output only valid when malfunctioning -> forces poisoner on WW seat
+- Drunk always unconstrained regardless of poisoner target
+- Combined Drunk+Poisoner: 234 + 108 + 18 + 18 = 378
+- Game class integration tests with malfunctioningSeats pass-through
+- End-to-end pipeline with Poisoner
+
+**Minor notes (non-blocking):**
+1. The "No Outsiders" variable identification in `buildFunctioningRoleConstrained` (line 792)
+   relies on it being the only variable without a pairOutputs entry. This works because
+   `buildMalfunctioningPairRoleInfo` creates the "No Outsiders" var first (before pair vars)
+   and doesn't add it to pairOutputs. Fragile but correct for now.
+
+2. The Chef's maximal variable count is `numPlayers + 1` (counts 0..numPlayers), which is
+   the same whether functioning or malfunctioning. Good - no variable count mismatch.
+
+3. CI passes on this branch.

--- a/ZDD_INTEGRATION_PLAN.md
+++ b/ZDD_INTEGRATION_PLAN.md
@@ -125,23 +125,76 @@ Test coverage: 20 tests (17 specified + 3 integration).
 
 ---
 
-## Prompt 5: Integration readiness
+## Prompt 7: Ravenkeeper, Scarlet Woman, Saint, Slayer
 
-**Status: Not started**
+**Status: Merged (PR #12). CI passing.**
 
-Clean API surface. Probably a high-level "shadow mode" function that takes the
-same inputs the botc-asp web app works with and produces comparable outputs.
-Verify browser bundleability. Maybe a small cross-validation script like we have
-for distributions.
+Rounds out the TB roles that interact with the existing phase structure:
 
-Now that we have the full Night 1 → Day 1 → Night 2 pipeline with Undertaker,
-integration can demonstrate multi-phase gameplay. Potential scope:
+- **Ravenkeeper**: Death-triggered Night 2 info role. When killed by Imp, wakes
+  and chooses a player to learn their role. Integrated into night-action.ts
+  branch logic with maximal variable allocation (TOP when not fired).
+- **Scarlet Woman**: Demon succession in recordDay(). Imp executed with 5+ alive
+  → living SW becomes new Imp. Reversible on undo. Also: functioning SW has
+  mandatory starpass precedence over other minions.
+- **Saint**: Game-ending condition. Functioning Saint executed → evil wins. Check
+  in recordDay() using _malfunctioningSeats.
+- **Slayer**: ZDD-based day ability. recordDay() builds exactlyOne ZDD of legal
+  (target, outcome) pairs. Recluse gets both died/survived outcomes (ST choice).
+  Undo restores _slayerUsed flag.
 
-- Browser bundle verification (ZDD + game engine in WASM-free JS)
-- Shadow mode: run ZDD engine alongside ASP engine in the web UI, compare outputs
-- Night 2 cross-validation script (extend `validate_night_info.py` pattern to
-  cover Night 2 action scenarios)
-- API surface cleanup: ensure Game class methods have a clean, documented interface
+Test coverage: 23 tests. CI passes on all 4 commits.
+
+---
+
+## Prompt 8: Browser bundle + observation API
+
+**Status: Merged (PR #13). CI passing.**
+
+Prepares botc-zdd- for web UI integration with two deliverables:
+
+**Browser bundle:**
+- `npm run build:browser` → `dist/botc-zdd.esm.js` via esbuild
+- No Node-only APIs (no fs/path/process)
+- `test-browser.html` smoke test: 5-player game, WW observation, Chef query,
+  undo verification. Works with `npx serve .`
+
+**GameObserver class:**
+- Wraps Game with high-level observation methods that translate human-readable
+  observations into ZDD require/exclude operations
+- Night 1: observePairInfo, observeCountInfo, observeFortuneTellerInfo,
+  observeLibrarianNoOutsiders
+- Night 2: observeNightDeath, observeEmpathN2, observeFortuneTellerN2,
+  observeUndertakerRole, observeRavenkeeperInfo
+- Day: observeExecution, observeNoExecution, observeSlayerShot
+- Queries: worldCount(), possibleValues(role, nightNumber) with human-readable
+  value descriptions and per-value world counts
+- Undo: per-observation undo stack with rollback on inconsistent observations
+- Error handling: inconsistent observations throw without modifying state
+
+Test coverage: 10 tests. All pass.
+
+---
+
+## Prompt 5: Web UI integration (botc-asp side)
+
+**Status: Not started — NEXT**
+
+This is work on the botc-asp repo, not botc-zdd-. The ZDD library is now
+feature-complete with a browser ESM bundle and observation API. The remaining
+task is wiring it into the botc-asp web UI as a shadow solver alongside clingo.
+
+Scope:
+- Add botc-zdd ESM bundle to web-ui (vendor dist/botc-zdd.esm.js or npm link)
+- Create Zdd.purs + Zdd.js FFI module (parallel to Clingo.purs + Clingo.js)
+- Translate Grimoire state (seat assignments, reminder tokens) into GameObserver
+  calls
+- Display ZDD world count alongside clingo model count
+- Optional: engine selector (Clingo / ZDD / Both) in game config UI
+- Optional: possibleValues display for each info role
+
+This is the final integration step — after this, the web UI runs both solvers
+and users can compare results.
 
 ---
 
@@ -151,7 +204,9 @@ integration can demonstrate multi-phase gameplay. Potential scope:
 - **Prompt 3 specifically**: Enables switching cross-validation to the real ASP oracle — **DONE**
 - **Prompt 4**: Enables multi-night games — **DONE**
 - **Prompt 6**: Day phase + Undertaker, completing the Night 1 → Day 1 → Night 2 loop — **DONE**
-- **Prompt 5**: Bridge back to this repo — **NEXT**
+- **Prompt 7**: Remaining TB roles (Ravenkeeper, SW, Saint, Slayer) — **DONE**
+- **Prompt 8**: Browser bundle + observation API (botc-zdd- side complete) — **DONE**
+- **Prompt 5**: Web UI integration (botc-asp side) — **NEXT**
 
 ---
 
@@ -317,3 +372,59 @@ Adds Day phase support and Undertaker role (+896 -31 across 4 files):
 
 **Cross-validation:** All 11 Night 1 info scenarios and 12 distribution scenarios
 continue to pass. ZDD performance unchanged (sub-2ms, 5 MB heap).
+
+### PR #12 Review (2026-03-13)
+
+**Verdict: Approve — Prompt 7 (Ravenkeeper, SW, Saint, Slayer)**
+
+Adds four TB roles (+1,097 -20 across 4 files, 4 commits, 23 tests):
+
+**Ravenkeeper (night-action.ts):**
+- Death-triggered: `buildRavenkeeperForBranch` returns TOP when RK not killed
+- Functioning: union of {targetVar(t)} × {roleVar(trueRole(t))} per target
+- Malfunctioning: exactlyOne(targets) × exactlyOne(roles)
+- Maximal variable allocation, per-branch TOP when inactive
+
+**Scarlet Woman (game.ts):**
+- Promotion in recordDay(): checks RoleType.Demon + aliveCount >= 5
+- Undo reverses promotion by restoring "Scarlet Woman" role
+- Starpass precedence (night-action.ts): functioning SW is mandatory recipient
+
+**Saint (game.ts):**
+- recordDay() check: executedRole === "Saint" && !malfunctioning → evil wins
+- GameOverResult type on DayResult
+
+**Slayer (game.ts — refactored from imperative to ZDD):**
+- Day phase ZDD variables: one per legal (target, outcome) pair
+- Recluse: both died/survived outcomes (registersAs Demon check)
+- Undo restores _slayerUsed flag
+- recordDay() overloaded to accept slayerShot option
+
+### PR #13 Review (2026-03-13)
+
+**Verdict: Approve — Prompt 8 (Browser bundle + observation API)**
+
+Adds browser bundle and GameObserver (+1,084 -108 across 6 files):
+
+**Browser bundle:**
+- `build:browser` script: esbuild → dist/botc-zdd.esm.js
+- test-browser.html: 5-player smoke test with observation + undo
+
+**GameObserver (src/observer.ts, 527 lines):**
+- Wraps Game, translates observations to require/exclude via find*Variable helpers
+- Night 1: observePairInfo, observeCountInfo, observeFortuneTellerInfo,
+  observeLibrarianNoOutsiders
+- Night 2: observeEmpathN2, observeFortuneTellerN2, observeUndertakerRole,
+  observeRavenkeeperInfo (two requires: target + role)
+- Day: observeExecution, observeNoExecution, observeSlayerShot
+- possibleValues: iterates role variables, requires each temporarily, returns
+  human-readable {value, worldCount} entries
+- Undo: per-observation stack, rollback on inconsistent observations
+- Error handling: BOTTOM check → restore previous root → throw
+
+**Minor notes (non-blocking):**
+1. Ravenkeeper undo pushes two entries (target + role) — caller must undo twice
+2. observeNightDeath not on undo stack (state transition, not ZDD observation)
+3. undo() uses private member cast for root restoration
+4. 10 tests covering possibleValues sums, observation narrowing, conflicts,
+   undo, full pipeline, Night 2 integration

--- a/ZDD_INTEGRATION_PLAN.md
+++ b/ZDD_INTEGRATION_PLAN.md
@@ -38,8 +38,7 @@ Established:
 
 ## Prompt 2: Poisoner + Drunk (malfunctioning info)
 
-**Status: PR #5 open, CI passing**
-**Branch: claude/add-poisoner-malfunctioning-roles-bDI3I**
+**Status: Merged (PR #5). Cross-validation passing.**
 
 The poisoner's target choice is part of the Night 1 phase — it happens before
 info roles act. This expands the Night 1 ZDD: for each poisoner target choice,
@@ -86,8 +85,43 @@ for distributions.
 ## Integration Milestones
 
 - **Prompts 1-3**: Minimum for useful integration (info roles with full TB complexity)
+- **Prompt 3 specifically**: Enables switching cross-validation to the real ASP oracle (see below)
 - **Prompt 4**: Enables multi-night games
 - **Prompt 5**: Bridge back to this repo
+
+---
+
+## Cross-Validation Strategy
+
+### Current state (Prompts 1-2)
+
+The night info cross-validation (`cross-validation/validate_night_info.py`) uses
+a **Python oracle** that independently computes expected world counts. This is
+NOT ideal — it reimplements the same spec as the ZDD, so shared misunderstandings
+of the spec would not be caught. We use it because the ZDD doesn't yet model
+Spy/Recluse registration or Fortune Teller, so running clingo against the full
+botc-asp rules would produce different (larger) answer set counts.
+
+Distribution cross-validation already uses the real clingo oracle and passes.
+
+### Target state (after Prompt 3)
+
+Once Prompt 3 lands (Spy/Recluse registration + Fortune Teller red herring), the
+ZDD's modeling scope for Night 1 info will match what the botc-asp ASP rules
+encode. At that point, **replace the Python oracle with clingo enumeration
+against the real ASP rules**:
+
+1. Feed clingo the concrete seat assignment + `botc.lp` + `tb.lp` + role files
+2. Enumerate all valid `st_tells_core` answer sets (including poisoner target,
+   malfunctioning outputs, Spy/Recluse registration, FT red herring)
+3. Count answer sets and compare against ZDD world count
+
+This is the real validation — two independent implementations (ASP declarative
+rules vs ZDD procedural builder) of the same game logic, compared by output.
+Any disagreement reveals a genuine bug in one or the other.
+
+**Priority: Switch to the ASP oracle as soon as Prompt 3 merges.** The Python
+oracle is a stopgap. Do not let it persist beyond Prompt 3.
 
 ---
 

--- a/cross-validation/benchmark_night_info.py
+++ b/cross-validation/benchmark_night_info.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Benchmark ASP (clingo) vs ZDD (botc-zdd-) for Night 1 info role counting.
+
+Measures wall-clock time per scenario for each engine, plus ZDD node counts.
+Reuses scenario definitions and helpers from validate_night_info.py.
+"""
+
+import time
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Reuse definitions from the validation script
+sys.path.insert(0, str(Path(__file__).parent))
+from validate_night_info import (
+    SCENARIOS, PLAYERS, ZDD_REPO, ASP_ROOT,
+    load_asp_program, count_asp_models, zdd_role_name,
+)
+
+
+def benchmark_asp(scenarios, base_program):
+    """Time each ASP scenario individually. Returns list of (name, count, seconds)."""
+    results = []
+    for sc in scenarios:
+        t0 = time.perf_counter()
+        count = count_asp_models(sc, base_program)
+        elapsed = time.perf_counter() - t0
+        results.append((sc["name"], count, elapsed))
+    return results
+
+
+ZDD_BENCH_SCRIPT = """
+const { ZDD } = require('./dist/zdd.js');
+const { TROUBLE_BREWING } = require('./dist/botc.js');
+const { buildNightInfoZDD } = require('./dist/night.js');
+
+const scenarios = %SCENARIOS%;
+const results = {};
+
+for (const [name, config] of Object.entries(scenarios)) {
+  const seatRoles = new Map();
+  for (const [seat, role] of Object.entries(config.seats)) {
+    seatRoles.set(Number(seat), role);
+  }
+
+  const zdd = new ZDD();
+  const t0 = process.hrtime.bigint();
+  const result = buildNightInfoZDD(zdd, {
+    numPlayers: config.player_count,
+    seatRoles,
+    selectedRoles: Object.values(config.seats),
+    script: TROUBLE_BREWING,
+  });
+  const count = zdd.count(result.root);
+  const elapsed = Number(process.hrtime.bigint() - t0) / 1e6;  // ms
+
+  results[name] = {
+    total: count,
+    variableCount: result.variableCount,
+    nodeCount: zdd.size,
+    elapsed_ms: elapsed,
+  };
+}
+
+// Memory usage
+const mem = process.memoryUsage();
+results["__memory__"] = {
+  rss_mb: (mem.rss / 1048576).toFixed(1),
+  heap_used_mb: (mem.heapUsed / 1048576).toFixed(1),
+  heap_total_mb: (mem.heapTotal / 1048576).toFixed(1),
+};
+
+console.log(JSON.stringify(results));
+"""
+
+
+def benchmark_zdd(scenarios):
+    """Run ZDD benchmarks. Returns dict of results per scenario."""
+    zdd_scenarios = {}
+    for sc in scenarios:
+        zdd_seats = {}
+        for seat, role in sc["seats"].items():
+            zdd_seats[str(seat)] = zdd_role_name(role)
+        zdd_scenarios[sc["name"]] = {
+            "seats": zdd_seats,
+            "player_count": sc["player_count"],
+        }
+
+    script = ZDD_BENCH_SCRIPT.replace("%SCENARIOS%", json.dumps(zdd_scenarios))
+    t0 = time.perf_counter()
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=str(ZDD_REPO),
+        capture_output=True,
+        text=True,
+    )
+    total_zdd_time = time.perf_counter() - t0
+    if result.returncode != 0:
+        print(f"ZDD error: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    data = json.loads(result.stdout)
+    data["__total_wall__"] = total_zdd_time
+    return data
+
+
+def main():
+    import resource
+
+    print("=" * 78)
+    print("Benchmark: ASP (clingo) vs ZDD (botc-zdd-) — Night 1 Info")
+    print("=" * 78)
+
+    base_program = load_asp_program()
+
+    # --- ASP benchmarks ---
+    print("\nASP (clingo) per-scenario timings:")
+    mem_before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    asp_total_t0 = time.perf_counter()
+    asp_results = benchmark_asp(SCENARIOS, base_program)
+    asp_total = time.perf_counter() - asp_total_t0
+    mem_after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    for name, count, elapsed in asp_results:
+        print(f"  {name:55s}  {count:>8,}  {elapsed*1000:8.1f} ms")
+
+    print(f"  {'TOTAL':55s}  {'':>8s}  {asp_total*1000:8.1f} ms")
+    print(f"  Peak RSS: ~{mem_after / 1024:.1f} MB")
+
+    # --- ZDD benchmarks ---
+    zdd_available = (ZDD_REPO / "dist" / "zdd.js").exists()
+    if not zdd_available:
+        print(f"\nZDD repo not found at {ZDD_REPO}, skipping ZDD benchmarks")
+        return
+
+    print("\nZDD (botc-zdd-) per-scenario timings:")
+    zdd_data = benchmark_zdd(SCENARIOS)
+    zdd_mem = zdd_data.get("__memory__", {})
+    zdd_wall = zdd_data.get("__total_wall__", 0)
+
+    for sc in SCENARIOS:
+        name = sc["name"]
+        if name in zdd_data:
+            d = zdd_data[name]
+            print(f"  {name:55s}  {d['total']:>8,}  {d['elapsed_ms']:8.1f} ms"
+                  f"  ({d['nodeCount']:,} nodes, {d['variableCount']} vars)")
+
+    print(f"  {'TOTAL (incl. Node startup)':55s}  {'':>8s}  {zdd_wall*1000:8.1f} ms")
+    if zdd_mem:
+        print(f"  Node RSS: {zdd_mem['rss_mb']} MB, Heap used: {zdd_mem['heap_used_mb']} MB")
+
+    # --- Summary ---
+    print("\n" + "=" * 78)
+    print("Per-scenario comparison (ms):")
+    print(f"  {'Scenario':<55s}  {'ASP':>8s}  {'ZDD':>8s}  {'Ratio':>7s}")
+    print(f"  {'-'*55}  {'-'*8}  {'-'*8}  {'-'*7}")
+    for (name, count, asp_ms) in asp_results:
+        if name in zdd_data:
+            zdd_ms = zdd_data[name]["elapsed_ms"]
+            ratio = (asp_ms * 1000) / zdd_ms if zdd_ms > 0 else float('inf')
+            print(f"  {name:55s}  {asp_ms*1000:8.1f}  {zdd_ms:8.1f}  {ratio:6.1f}x")
+    print("=" * 78)
+
+
+if __name__ == "__main__":
+    main()

--- a/cross-validation/count_distrib.py
+++ b/cross-validation/count_distrib.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Count valid TB distributions for various player counts using clingo.
+This provides oracle values to cross-validate against botc-zdd-.
+"""
+
+import clingo
+import sys
+import json
+from pathlib import Path
+
+def count_distributions(player_count: int, include_baron: bool = True) -> dict:
+    """Count valid role distributions for a given player count.
+
+    Returns dict with:
+      - count: number of valid distributions
+      - distributions: list of role sets (each a sorted list of role names)
+    """
+    ctl = clingo.Control(["0"])  # enumerate all models
+
+    # Load the distribution-counting ASP program
+    asp_file = Path(__file__).parent / "count_distributions.lp"
+    ctl.load(str(asp_file))
+
+    # Set player count
+    ctl.add("base", [], f"#const player_count = {player_count}.")
+
+    # If not including Baron adjustment, exclude Baron from distribution
+    if not include_baron:
+        ctl.add("base", [], ":- distrib(baron).")
+
+    ctl.ground([("base", [])])
+
+    distributions = []
+
+    def on_model(model):
+        atoms = model.symbols(shown=True)
+        roles = sorted([str(a.arguments[0]) for a in atoms if a.name == "distrib"])
+        distributions.append(roles)
+
+    result = ctl.solve(on_model=on_model)
+
+    return {
+        "player_count": player_count,
+        "include_baron": include_baron,
+        "count": len(distributions),
+        "satisfiable": result.satisfiable,
+        "distributions": distributions,
+    }
+
+
+def main():
+    player_counts = [5, 6, 7, 8, 9, 10]
+
+    results = {}
+
+    for pc in player_counts:
+        # Without Baron adjustment (Baron can be in play but no outsider swap)
+        # Actually: "without Baron" means Baron is excluded entirely
+        no_baron = count_distributions(pc, include_baron=False)
+        with_baron = count_distributions(pc, include_baron=True)
+
+        results[pc] = {
+            "no_baron": no_baron["count"],
+            "with_baron": with_baron["count"],
+            "baron_only": with_baron["count"] - no_baron["count"],
+        }
+
+        print(f"\n=== {pc} players ===")
+        print(f"  Without Baron: {no_baron['count']} distributions")
+        print(f"  With Baron:    {with_baron['count']} distributions")
+        print(f"  Baron-only:    {with_baron['count'] - no_baron['count']} additional")
+
+        # Show a few sample distributions
+        if no_baron["count"] <= 10:
+            print(f"  All distributions (no Baron):")
+            for d in sorted(no_baron["distributions"]):
+                print(f"    {d}")
+
+    # Output JSON for machine consumption
+    json_path = Path(__file__).parent / "oracle_counts.json"
+
+    # Also save full distribution sets for small cases
+    detail = {}
+    for pc in player_counts:
+        no_baron = count_distributions(pc, include_baron=False)
+        with_baron = count_distributions(pc, include_baron=True)
+        detail[str(pc)] = {
+            "no_baron": {
+                "count": no_baron["count"],
+                "distributions": sorted(no_baron["distributions"]),
+            },
+            "with_baron": {
+                "count": with_baron["count"],
+                "distributions": sorted(with_baron["distributions"]),
+            },
+        }
+
+    with open(json_path, "w") as f:
+        json.dump(detail, f, indent=2)
+
+    print(f"\nOracle data written to {json_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cross-validation/count_distributions.lp
+++ b/cross-validation/count_distributions.lp
@@ -1,0 +1,68 @@
+% Minimal distribution counter for cross-validation with botc-zdd-
+% This only counts valid role SETS (which roles are in play),
+% ignoring seat assignments, night actions, etc.
+
+% Include script definitions for role categories
+% (we inline TB roles rather than including tb.lp which pulls in all game logic)
+
+% Trouble Brewing roles
+townsfolk(washerwoman; librarian; investigator; chef; empath; fortune_teller; undertaker; monk; ravenkeeper; virgin; slayer; soldier; mayor).
+outsider(butler; drunk; recluse; saint).
+minion(poisoner; spy; scarlet_woman; baron).
+demon(imp).
+
+role(X) :- townsfolk(X).
+role(X) :- outsider(X).
+role(X) :- minion(X).
+role(X) :- demon(X).
+
+% Baron's outsider adjustment
+causes_outsider_mod(baron, 1) :- player_count < 7.
+causes_outsider_mod(baron, 2) :- player_count >= 7.
+causes_townsfolk_mod(R, -N) :- causes_outsider_mod(R, N).
+
+% Base distribution counts (from botc.lp)
+base_townsfolk(3) :- 5 <= player_count, player_count <= 6.
+base_townsfolk(5) :- 7 <= player_count, player_count <= 9.
+base_townsfolk(7) :- 10 <= player_count, player_count <= 12.
+base_townsfolk(9) :- 13 <= player_count, player_count <= 15.
+
+base_outsider(player_count - 5) :- 5 <= player_count, player_count <= 6.
+base_outsider(player_count - 7) :- 7 <= player_count, player_count <= 9.
+base_outsider(player_count - 10) :- 10 <= player_count, player_count <= 12.
+base_outsider(player_count - 13) :- 13 <= player_count, player_count <= 15.
+
+base_minion(1) :- 5 <= player_count, player_count <= 9.
+base_minion(2) :- 10 <= player_count, player_count <= 12.
+base_minion(3) :- 13 <= player_count, player_count <= 15.
+
+base_demon(1).
+
+% Choose a distribution: select roles to be "in play"
+{ distrib(X) : townsfolk(X) }.
+{ distrib(X) : outsider(X) }.
+{ distrib(X) : minion(X) }.
+{ distrib(X) : demon(X) }.
+
+% Outsider adjustment (only Baron in TB)
+outsider_adjustment(A) :- A = #sum { N, R : causes_outsider_mod(R, N), distrib(R) }.
+townsfolk_adjustment(A) :- A = #sum { N, R : causes_townsfolk_mod(R, N), distrib(R) }.
+
+% No minion/demon adjustments in TB, but define them for completeness
+causes_minion_mod(none, 0) :- #false.
+causes_demon_mod(none, 0) :- #false.
+minion_adjustment(A) :- A = #sum { N, R : causes_minion_mod(R, N), distrib(R) }.
+demon_adjustment(A) :- A = #sum { N, R : causes_demon_mod(R, N), distrib(R) }.
+
+adjusted_townsfolk(B + A) :- base_townsfolk(B), townsfolk_adjustment(A).
+adjusted_outsider(B + A) :- base_outsider(B), outsider_adjustment(A).
+adjusted_minion(B + A) :- base_minion(B), minion_adjustment(A).
+adjusted_demon(B + A) :- base_demon(B), demon_adjustment(A).
+
+% Enforce correct counts
+:- adjusted_townsfolk(N), #count { R : distrib(R), townsfolk(R) } != N.
+:- adjusted_outsider(N), #count { R : distrib(R), outsider(R) } != N.
+:- adjusted_minion(N), #count { R : distrib(R), minion(R) } != N.
+:- adjusted_demon(N), #count { R : distrib(R), demon(R) } != N.
+
+#show distrib/1.

--- a/cross-validation/prompt4_night_actions.md
+++ b/cross-validation/prompt4_night_actions.md
@@ -1,0 +1,247 @@
+# Prompt 4: Night 2+ Actions — Demon Kill, Monk Protection, Death
+
+## Context
+
+Prompts 1–3 built the Night 1 info phase: for a concrete seat assignment, the
+ZDD represents all valid Storyteller information choices (Washerwoman, Librarian,
+Investigator, Chef, Empath, Fortune Teller) accounting for Poisoner/Drunk
+malfunctioning and Spy/Recluse registration.
+
+Prompt 4 extends the game into **Night 2+**, adding the first "action" roles —
+roles whose choices change game state rather than just producing information.
+
+## Goal
+
+Add a new phase builder for **Night 2+ actions** that, given a concrete seat
+assignment and a concrete Night 1 info result, builds a ZDD representing all
+valid Storyteller + player choice combinations for Night 2. The key new
+mechanics are:
+
+1. **Poisoner retargets** (already exists as a concept — new target for Night 2)
+2. **Monk protection** (new)
+3. **Imp demon kill** (new)
+4. **Death** (new — a player may die, changing the game state)
+5. **Night 2 info roles** (Empath, Fortune Teller re-query with updated state)
+
+## Night 2 Role Order
+
+From the Trouble Brewing script, the Other Night order is:
+
+| Order | Role             | Type           | Notes                           |
+|-------|------------------|----------------|---------------------------------|
+| 1     | Poisoner         | Choice         | Picks new poison target         |
+| 2     | Monk             | Choice         | Picks player to protect (not self) |
+| 3     | Scarlet Woman    | Automatic      | No player choice; just a timing slot |
+| 4     | Imp              | Choice         | Picks kill target (can self-target = starpass) |
+| 5     | Ravenkeeper      | Conditional    | Only acts if died tonight (skip for now) |
+| 6     | Empath           | Info (count)   | Living evil neighbors (updated for deaths) |
+| 7     | Fortune Teller   | Info (pair+yn) | Same as Night 1 but new FT choice |
+| 8     | Undertaker       | Info           | Who was executed today (skip for now) |
+| 9     | Butler           | Choice         | Skip for now                    |
+| 10    | Spy              | Automatic      | No new variables needed         |
+
+**In scope for this prompt:** Poisoner, Monk, Imp, Empath, Fortune Teller.
+**Out of scope:** Ravenkeeper, Undertaker, Butler (these can be added later
+without changing the architecture).
+
+## Detailed Specifications
+
+### Poisoner (Order 1)
+
+The Poisoner picks a new target for Night 2. This works exactly like Night 1
+Poisoner targeting — one variable per eligible target seat, exactlyOne
+constraint. The Night 1 poison expires at the start of Night 2; the new target
+becomes poisoned for Night 2's remaining roles.
+
+**Variables:** One per player seat (excluding the Poisoner's own seat), same as
+Night 1.
+
+**Interaction:** The new poison target determines which roles malfunction during
+Night 2 — this includes the Monk (a poisoned Monk's protection does nothing)
+and info roles (poisoned Empath gets unconstrained output).
+
+### Monk (Order 2) — NEW
+
+The Monk chooses one player to protect from demon kill. Constraints:
+- **Cannot protect self**
+- The Monk must be alive at the start of Night 2
+- If the Monk is **poisoned/drunk**, they still make a choice (they're woken up
+  as normal), but the protection token has no effect
+
+**Variables:** One variable per eligible target (all players except the Monk),
+with an exactlyOne constraint.
+
+**Effect:** If the Monk is functioning, the protected player survives demon
+kill. If the Monk is malfunctioning (poisoned/drunk), the choice is made but
+protection does not apply.
+
+**Branching pattern:** Similar to Poisoner — for each Poisoner target branch,
+if the Monk is the poison target, the Monk's protection is nullified. Cross
+these branches with Monk target choices.
+
+### Imp Kill (Order 4) — NEW
+
+The Imp chooses one player to kill. Constraints:
+- Can target **any** player, including itself (starpass)
+- **Starpass** (self-target) is only legal if at least one living minion exists
+  to receive the demon role
+- The Imp must be alive and functioning to place the kill token
+- If the Imp is poisoned, they still choose a target but nobody dies
+
+**Variables:** One variable per target player, exactlyOne constraint.
+
+**Kill resolution:** After the Imp's choice, the kill succeeds unless:
+1. The target is protected by a functioning Monk, OR
+2. The Imp is malfunctioning (poisoned/drunk)
+
+If the kill succeeds, the target **dies**. This affects subsequent info roles
+in the same night.
+
+### Starpass Sub-choices — NEW
+
+When the Imp targets itself and the kill succeeds:
+1. The Imp dies
+2. The ST chooses one living minion (from initial minion assignments) to become
+   the new Imp
+3. The chosen minion's role changes to Imp immediately
+
+**Variables:** When starpass is possible, add one variable per eligible minion
+recipient, with an exactlyOne constraint (only within the starpass sub-branch).
+
+**Note:** Starpass is a relatively rare edge case. It's fine to handle it as
+additional branches within the Imp's target selection. If starpass is impossible
+(no living minions), the Imp cannot self-target — that target variable is
+excluded entirely.
+
+### Death State — NEW
+
+This is the key architectural addition. After the Imp's action resolves:
+- If the kill succeeded, exactly one player is now dead
+- If the kill failed (Monk protection or Imp poisoned), nobody new is dead
+
+The death state affects:
+1. **Empath neighbor calculation** — dead players are skipped when finding
+   living neighbors
+2. **Fortune Teller choices** — dead players are still valid FT targets (the FT
+   picks any two players regardless of alive/dead status)
+3. **Future nights** — dead players don't wake up (not relevant for this prompt,
+   but the architecture should support it)
+
+**Encoding suggestion:** You don't necessarily need explicit "death" variables.
+Since the Imp target + Monk protection + poison status fully determine who dies,
+the death outcome is implicit in the branch structure. Each branch of the ZDD
+already knows "in this world, player X died" or "nobody died."
+
+### Night 2 Empath (Order 6)
+
+Same as Night 1 Empath, but:
+- **Living neighbor calculation changes** if someone died this night
+- If the Empath is the one who died, they don't wake up (no Empath output)
+- If a neighbor of the Empath died, the Empath's living neighbors shift
+- If the Empath is poisoned (Night 2 Poisoner target), output is unconstrained
+
+**Key complexity:** The Empath's correct output depends on the kill outcome,
+which depends on the Imp target × Monk protection × Poisoner target
+interaction. Each branch of the ZDD may produce a different Empath count.
+
+### Night 2 Fortune Teller (Order 7)
+
+Same as Night 1 FT, but:
+- The FT makes a **new** pair choice for Night 2 (independent of Night 1)
+- The **red herring is fixed** for the whole game (chosen during setup/Night 1)
+- If the FT died this night, no FT output
+- If the FT is poisoned, output is unconstrained
+
+### Soldier Immunity (Stretch Goal)
+
+The Soldier is immune to demon kill when functioning. Not yet implemented in
+the ASP either (`soldier.lp` is a TODO stub), but the architecture should
+make it easy to add later:
+- If the Imp targets the Soldier and the Soldier is functioning → kill fails
+- If the Soldier is poisoned → immunity lost, kill succeeds
+
+This is structurally similar to Monk protection — it adds another condition
+to the "does the kill succeed?" check. Can be a follow-up PR.
+
+## Architectural Guidance
+
+### Branching Structure
+
+Night 2 has a **cascade of dependent choices**:
+
+```
+Poisoner target (N-1 branches)
+  └─ Monk target (N-1 branches, but Monk malfunctions if poisoned)
+       └─ Imp target (N branches, starpass conditional)
+            └─ Kill outcome (determined by above)
+                 └─ Empath output (depends on who died)
+                 └─ FT pair choice + output (depends on who died)
+```
+
+This is more complex than Night 1's branching (which was just Poisoner ×
+FT red herring). You'll likely need to:
+
+1. Build the choice variables for Poisoner, Monk, Imp in sequence
+2. For each combination, determine the kill outcome
+3. Build info role outputs conditional on the outcome
+4. Union all branches
+
+**Optimization:** Many branches produce the same info role outputs (e.g., if
+the Imp kills player 3 and the Empath's neighbors are players 1 and 5, the
+Empath count is the same regardless of who the Monk protected). The ZDD's
+structural sharing should compress these naturally.
+
+### Variable Layout
+
+Suggested variable ordering within the Night 2 phase:
+
+```
+[Poisoner targets] [Monk targets] [Imp targets] [Starpass recipients] [Empath outputs] [FT outputs]
+```
+
+All variables should be allocated upfront (maximal set), then constrained per
+branch — same pattern as the existing Night 1 builder.
+
+### Phase Integration
+
+This should be a new phase in the Game class (e.g., `PhaseType.NightAction` or
+`PhaseType.Night2`). It takes as input:
+- The concrete seat assignment (from Phase 2)
+- Malfunctioning seats from Night 1 (Drunk is always malfunctioning)
+- Red herring designation (from Night 1 — carries forward)
+
+The Game class should support building this phase after the Night 1 info phase.
+
+### What NOT to Build
+
+- **Day phase** (nominations, voting, execution) — that's a future prompt
+- **Multi-night loop** (Night 3, 4, ...) — just Night 2 for now
+- **Ravenkeeper/Undertaker/Butler** — can be added as incremental follow-ups
+- **Scarlet Woman promotion** — only triggers on execution (day phase), so
+  it doesn't affect Night 2 actions. But be aware it exists for later.
+- **Game-over detection** — the ZDD doesn't need to check win conditions
+
+## Cross-Validation
+
+After implementation, the cross-validation script in `botc-asp/cross-validation/`
+can be extended to verify Night 2 counts. The ASP oracle approach works the same
+way: fix a seat assignment, project onto observable atoms (Poisoner target, Monk
+target, Imp target, kill outcome, Empath output, FT output), and count models.
+
+A good first test scenario:
+- **5p: Monk, Chef, Empath, Poisoner, Imp** — Monk + Poisoner + Imp all active,
+  Chef provides no Night 2 info (simplifies verification)
+- **5p: Monk, Empath, FT, Poisoner, Imp** — adds FT Night 2 output
+
+## Deliverables
+
+1. Night 2 action builder function (analogous to `buildNightInfoZDD`)
+2. Tests covering:
+   - Monk protection blocks Imp kill
+   - Poisoned Monk's protection has no effect
+   - Poisoned Imp's kill has no effect
+   - Imp starpass mechanics
+   - Empath output changes based on who died
+   - Branch count verification against hand-calculated expectations
+3. Game class integration (new phase after NightInfo)
+4. Exported types for new variable categories (MonkTarget, ImpTarget, etc.)

--- a/cross-validation/validate_distributions.py
+++ b/cross-validation/validate_distributions.py
@@ -114,13 +114,13 @@ def clingo_count_distributions(player_count: int, exclude_baron: bool = False) -
 
 ZDD_SCRIPT = """
 const { ZDD } = require('./dist/zdd.js');
-const { buildDistributionZDD, buildDistributionZDDWithBaron, TROUBLE_BREWING } = require('./dist/botc.js');
+const { buildDistributionZDD, buildDistributionZDDWithModifiers, TROUBLE_BREWING } = require('./dist/botc.js');
 
 const results = {};
 for (const pc of %PLAYER_COUNTS%) {
   const zdd = new ZDD();
   const noBaron = buildDistributionZDD(zdd, TROUBLE_BREWING, pc);
-  const withBaron = buildDistributionZDDWithBaron(zdd, TROUBLE_BREWING, pc);
+  const withBaron = buildDistributionZDDWithModifiers(zdd, TROUBLE_BREWING, pc);
 
   // Enumerate distributions for the no-baron case to compare sets
   const noBaronSets = zdd.enumerate(noBaron).map(vars =>

--- a/cross-validation/validate_distributions.py
+++ b/cross-validation/validate_distributions.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+Cross-validate botc-zdd- distribution counts against clingo oracle.
+
+This script:
+1. Runs clingo on a minimal distribution-only ASP program (ground truth)
+2. Runs the botc-zdd- library via Node.js subprocess
+3. Compares the counts and reports mismatches
+
+Requirements:
+- Python clingo package: pip install clingo
+- botc-zdd- repo cloned and built: cd ../botc-zdd- && npx tsc
+"""
+
+import clingo
+import subprocess
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+ZDD_REPO = SCRIPT_DIR.parent.parent / "botc-zdd-"
+
+# =============================================================================
+# Clingo Oracle
+# =============================================================================
+
+DISTRIBUTION_ASP = """
+% Trouble Brewing roles
+townsfolk(washerwoman; librarian; investigator; chef; empath; fortune_teller;
+          undertaker; monk; ravenkeeper; virgin; slayer; soldier; mayor).
+outsider(butler; drunk; recluse; saint).
+minion(poisoner; spy; scarlet_woman; baron).
+demon(imp).
+
+role(X) :- townsfolk(X).
+role(X) :- outsider(X).
+role(X) :- minion(X).
+role(X) :- demon(X).
+
+% Baron's outsider adjustment (differs by player count!)
+causes_outsider_mod(baron, 1) :- player_count < 7.
+causes_outsider_mod(baron, 2) :- player_count >= 7.
+causes_townsfolk_mod(R, -N) :- causes_outsider_mod(R, N).
+
+% Base distribution counts
+base_townsfolk(3) :- 5 <= player_count, player_count <= 6.
+base_townsfolk(5) :- 7 <= player_count, player_count <= 9.
+base_townsfolk(7) :- 10 <= player_count, player_count <= 12.
+base_townsfolk(9) :- 13 <= player_count, player_count <= 15.
+
+base_outsider(player_count - 5) :- 5 <= player_count, player_count <= 6.
+base_outsider(player_count - 7) :- 7 <= player_count, player_count <= 9.
+base_outsider(player_count - 10) :- 10 <= player_count, player_count <= 12.
+base_outsider(player_count - 13) :- 13 <= player_count, player_count <= 15.
+
+base_minion(1) :- 5 <= player_count, player_count <= 9.
+base_minion(2) :- 10 <= player_count, player_count <= 12.
+base_minion(3) :- 13 <= player_count, player_count <= 15.
+base_demon(1).
+
+% Choose roles to distribute
+{ distrib(X) : townsfolk(X) }.
+{ distrib(X) : outsider(X) }.
+{ distrib(X) : minion(X) }.
+{ distrib(X) : demon(X) }.
+
+% Adjustments
+outsider_adjustment(A) :- A = #sum { N, R : causes_outsider_mod(R, N), distrib(R) }.
+townsfolk_adjustment(A) :- A = #sum { N, R : causes_townsfolk_mod(R, N), distrib(R) }.
+causes_minion_mod(none, 0) :- #false.
+causes_demon_mod(none, 0) :- #false.
+minion_adjustment(A) :- A = #sum { N, R : causes_minion_mod(R, N), distrib(R) }.
+demon_adjustment(A) :- A = #sum { N, R : causes_demon_mod(R, N), distrib(R) }.
+
+adjusted_townsfolk(B + A) :- base_townsfolk(B), townsfolk_adjustment(A).
+adjusted_outsider(B + A) :- base_outsider(B), outsider_adjustment(A).
+adjusted_minion(B + A) :- base_minion(B), minion_adjustment(A).
+adjusted_demon(B + A) :- base_demon(B), demon_adjustment(A).
+
+% Enforce correct category counts
+:- adjusted_townsfolk(N), #count { R : distrib(R), townsfolk(R) } != N.
+:- adjusted_outsider(N), #count { R : distrib(R), outsider(R) } != N.
+:- adjusted_minion(N), #count { R : distrib(R), minion(R) } != N.
+:- adjusted_demon(N), #count { R : distrib(R), demon(R) } != N.
+
+#show distrib/1.
+"""
+
+
+def clingo_count_distributions(player_count: int, exclude_baron: bool = False) -> dict:
+    """Run clingo to count valid distributions. Returns {count, distributions}."""
+    ctl = clingo.Control(["0"])
+    program = DISTRIBUTION_ASP
+    program += f"\n#const player_count = {player_count}.\n"
+    if exclude_baron:
+        program += ":- distrib(baron).\n"
+    ctl.add("base", [], program)
+    ctl.ground([("base", [])])
+
+    distributions = []
+    def on_model(model):
+        atoms = model.symbols(shown=True)
+        roles = sorted(str(a.arguments[0]) for a in atoms if a.name == "distrib")
+        distributions.append(roles)
+
+    ctl.solve(on_model=on_model)
+    return {"count": len(distributions), "distributions": sorted(distributions)}
+
+
+# =============================================================================
+# ZDD Runner
+# =============================================================================
+
+ZDD_SCRIPT = """
+const { ZDD } = require('./dist/zdd.js');
+const { buildDistributionZDD, buildDistributionZDDWithBaron, TROUBLE_BREWING } = require('./dist/botc.js');
+
+const results = {};
+for (const pc of %PLAYER_COUNTS%) {
+  const zdd = new ZDD();
+  const noBaron = buildDistributionZDD(zdd, TROUBLE_BREWING, pc);
+  const withBaron = buildDistributionZDDWithBaron(zdd, TROUBLE_BREWING, pc);
+
+  // Enumerate distributions for the no-baron case to compare sets
+  const noBaronSets = zdd.enumerate(noBaron).map(vars =>
+    vars.map(v => TROUBLE_BREWING.roles[v].name).sort()
+  ).sort();
+
+  const withBaronSets = zdd.enumerate(withBaron).map(vars =>
+    vars.map(v => TROUBLE_BREWING.roles[v].name).sort()
+  ).sort();
+
+  results[pc] = {
+    no_baron_count: zdd.count(noBaron),
+    with_baron_count: zdd.count(withBaron),
+    no_baron_sets: noBaronSets,
+    with_baron_sets: withBaronSets,
+  };
+}
+console.log(JSON.stringify(results));
+"""
+
+
+def run_zdd(player_counts: list[int]) -> dict:
+    """Run botc-zdd- and return distribution counts."""
+    script = ZDD_SCRIPT.replace("%PLAYER_COUNTS%", json.dumps(player_counts))
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=str(ZDD_REPO),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"ZDD error: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(result.stdout)
+
+
+# =============================================================================
+# Comparison
+# =============================================================================
+
+def normalize_role_name(asp_name: str) -> str:
+    """Convert ASP role name to ZDD role name format.
+    ASP uses: fortune_teller, scarlet_woman
+    ZDD uses: Fortune Teller, Scarlet Woman
+    """
+    return asp_name.replace("_", " ").title()
+
+
+def normalize_asp_distribution(dist: list[str]) -> list[str]:
+    """Convert ASP distribution to ZDD format for comparison."""
+    return sorted(normalize_role_name(r) for r in dist)
+
+
+def compare(player_counts: list[int]):
+    """Run full comparison."""
+    print("=" * 70)
+    print("Cross-validation: botc-asp (clingo) vs botc-zdd- (ZDD)")
+    print("=" * 70)
+
+    # Only enumerate full sets for small player counts to avoid memory issues
+    enumerate_threshold = 8
+
+    zdd_results = run_zdd(player_counts)
+
+    all_pass = True
+
+    for pc in player_counts:
+        print(f"\n--- {pc} players ---")
+
+        # Clingo oracle
+        asp_no_baron = clingo_count_distributions(pc, exclude_baron=True)
+        asp_with_baron = clingo_count_distributions(pc, exclude_baron=False)
+
+        # ZDD results
+        zdd = zdd_results[str(pc)]
+
+        # Compare counts
+        nb_match = asp_no_baron["count"] == zdd["no_baron_count"]
+        wb_match = asp_with_baron["count"] == zdd["with_baron_count"]
+
+        nb_status = "PASS" if nb_match else "FAIL"
+        wb_status = "PASS" if wb_match else "FAIL"
+
+        print(f"  No-Baron:   ASP={asp_no_baron['count']:>6}  ZDD={zdd['no_baron_count']:>6}  [{nb_status}]")
+        print(f"  With-Baron: ASP={asp_with_baron['count']:>6}  ZDD={zdd['with_baron_count']:>6}  [{wb_status}]")
+
+        if not nb_match or not wb_match:
+            all_pass = False
+
+        # For small counts, compare actual distribution sets
+        if pc <= enumerate_threshold and not wb_match:
+            asp_sets = set(tuple(normalize_asp_distribution(d)) for d in asp_with_baron["distributions"])
+            zdd_sets = set(tuple(d) for d in zdd["with_baron_sets"])
+
+            only_asp = asp_sets - zdd_sets
+            only_zdd = zdd_sets - asp_sets
+
+            if only_asp:
+                print(f"  In ASP but not ZDD ({len(only_asp)} sets):")
+                for s in sorted(only_asp)[:5]:
+                    print(f"    {list(s)}")
+                if len(only_asp) > 5:
+                    print(f"    ... and {len(only_asp) - 5} more")
+
+            if only_zdd:
+                print(f"  In ZDD but not ASP ({len(only_zdd)} sets):")
+                for s in sorted(only_zdd)[:5]:
+                    print(f"    {list(s)}")
+                if len(only_zdd) > 5:
+                    print(f"    ... and {len(only_zdd) - 5} more")
+
+    print("\n" + "=" * 70)
+    if all_pass:
+        print("ALL CHECKS PASSED")
+    else:
+        print("SOME CHECKS FAILED — see details above")
+        print()
+        print("Known bugs in botc-zdd-:")
+        print("  1. buildDistributionZDD includes Baron as valid minion without")
+        print("     requiring Baron's outsider adjustment. Baron should be excluded")
+        print("     from non-modified distributions.")
+        print("  2. buildDistributionZDDWithBaron hardcodes +2/-2 outsider/townsfolk")
+        print("     modifier, but for player_count < 7, Baron only adds +1/-1.")
+    print("=" * 70)
+
+    return all_pass
+
+
+def main():
+    player_counts = [5, 6, 7, 8, 9, 10]
+    success = compare(player_counts)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/cross-validation/validate_night_info.py
+++ b/cross-validation/validate_night_info.py
@@ -1,13 +1,24 @@
 #!/usr/bin/env python3
 """
-Cross-validate botc-zdd- Night 1 info role outputs against clingo oracle.
+Cross-validate botc-zdd- Night 1 info role outputs against clingo ASP oracle.
 
-For a fixed seat assignment, counts the number of valid ST information
-choices per info role and compares ZDD vs ASP results.
+Uses the actual ASP game logic (botc.lp + tb.lp) as ground truth, projecting
+onto observable atoms to count distinct Storyteller choice combinations.
 
-When the Poisoner is in play, the oracle computes per-branch world counts
-(one branch per poisoner target), where the targeted info role gets
-unconstrained outputs. The total world count is the sum across branches.
+For a fixed seat assignment, the number of valid ST choice combos should match
+the ZDD world count.
+
+**Projection atoms** (what the ZDD tracks):
+- st_tells_core/4: each info role's output
+- poi_target/1: which player the Poisoner targets (derived from poi_poisoned)
+- ft_red_herring/1: which player is the FT red herring (derived from ft_red_herring)
+
+**Known discrepancies** (documented, not bugs in the cross-validation):
+- ASP Chef malfunctioning range is 0..player_count/2 (correct per game rules).
+  ZDD uses 0..numPlayers (too wide). ZDD bug, tracked separately.
+- ASP pair-based info roles (WW/Lib/Inv) allow naming ANY role the reference
+  player may_register_as, not just roles of the target type. E.g., WW can name
+  "Butler" when Spy is the reference. ASP bug, tracked separately.
 
 Requirements:
 - Python clingo package: pip install clingo
@@ -21,238 +32,168 @@ import sys
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent
-ZDD_REPO = SCRIPT_DIR.parent.parent / "botc-zdd-"
+ASP_ROOT = SCRIPT_DIR.parent
+ZDD_REPO = ASP_ROOT.parent / "botc-zdd-"
 
-# =============================================================================
-# Role categories (Trouble Brewing)
-# =============================================================================
+# Player names from players.lp, indexed by chair number
+PLAYERS = [
+    "amanda", "rob", "taylor", "courtney", "steph",
+    "felix", "neha", "pratik", "kunjal", "cyrielle",
+    "logan", "lou", "kate", "ivan", "ricky", "kyla",
+]
 
-TOWNSFOLK = {"washerwoman", "librarian", "investigator", "chef", "empath",
-             "fortune_teller", "undertaker", "monk", "ravenkeeper",
-             "virgin", "slayer", "soldier", "mayor"}
-
-OUTSIDERS = {"butler", "drunk", "recluse", "saint"}
-
-MINIONS = {"poisoner", "spy", "scarlet_woman", "baron"}
-
-DEMONS = {"imp"}
-
-ALL_TOWNSFOLK_COUNT = len(TOWNSFOLK)  # 13
-ALL_OUTSIDER_COUNT = len(OUTSIDERS)   # 4
-ALL_MINION_COUNT = len(MINIONS)       # 4
 
 # =============================================================================
 # Test scenarios
 # =============================================================================
 
 SCENARIOS = [
+    # --- No Poisoner, no Spy/Recluse, no FT ---
     {
-        "name": "5p: WW,Chef,Empath,Poisoner,Imp",
+        "name": "5p basic: WW,Chef,Empath,SW,Imp",
+        "seats": {0: "washerwoman", 1: "chef", 2: "empath", 3: "scarlet_woman", 4: "imp"},
+        "player_count": 5,
+    },
+    # --- Poisoner, no Spy/Recluse ---
+    {
+        "name": "5p Poisoner: WW,Chef,Empath,Poisoner,Imp",
         "seats": {0: "washerwoman", 1: "chef", 2: "empath", 3: "poisoner", 4: "imp"},
         "player_count": 5,
+        "known_discrepancy": "Chef malfunctioning range: ASP uses 0..N/2, ZDD uses 0..N",
     },
     {
-        "name": "5p: Poisoner,WW,Empath,Imp,Chef",
+        "name": "5p Poisoner rotated: Poisoner,WW,Empath,Imp,Chef",
         "seats": {0: "poisoner", 1: "washerwoman", 2: "empath", 3: "imp", 4: "chef"},
         "player_count": 5,
+        "known_discrepancy": "Chef malfunctioning range",
     },
+    # --- Spy (no Poisoner) ---
     {
-        "name": "5p: Investigator,Soldier,Virgin,Poisoner,Imp",
-        "seats": {0: "investigator", 1: "soldier", 2: "virgin", 3: "poisoner", 4: "imp"},
-        "player_count": 5,
-    },
-    {
-        "name": "6p: Librarian,Chef,Empath,Butler,Poisoner,Imp",
-        "seats": {0: "librarian", 1: "chef", 2: "empath", 3: "butler", 4: "poisoner", 5: "imp"},
-        "player_count": 6,
-    },
-    {
-        "name": "7p: WW,Lib,Inv,Chef,Empath,Poisoner,Imp",
-        "seats": {0: "washerwoman", 1: "librarian", 2: "investigator", 3: "chef", 4: "empath", 5: "poisoner", 6: "imp"},
-        "player_count": 7,
-    },
-    # No-Poisoner scenarios (use Spy as the minion)
-    {
-        "name": "5p: WW,Chef,Empath,Spy,Imp (no Poisoner)",
+        "name": "5p Spy: WW,Chef,Empath,Spy,Imp",
         "seats": {0: "washerwoman", 1: "chef", 2: "empath", 3: "spy", 4: "imp"},
         "player_count": 5,
+        "known_discrepancy": "ASP WW may_register_as_role includes non-townsfolk for Spy",
+    },
+    # --- Recluse (no Poisoner) ---
+    {
+        "name": "5p Recluse: WW,Chef,Recluse,SW,Imp",
+        "seats": {0: "washerwoman", 1: "chef", 2: "recluse", 3: "scarlet_woman", 4: "imp"},
+        "player_count": 5,
     },
     {
-        "name": "7p: WW,Lib,Inv,Chef,Empath,Spy,Imp (no Poisoner)",
+        "name": "5p Recluse+Inv: Investigator,Chef,Recluse,SW,Imp",
+        "seats": {0: "investigator", 1: "chef", 2: "recluse", 3: "scarlet_woman", 4: "imp"},
+        "player_count": 5,
+        "known_discrepancy": "ASP Inv may_register_as_role includes non-minion for Recluse",
+    },
+    # --- Fortune Teller (no Poisoner) ---
+    {
+        "name": "5p FT: FT,Chef,Empath,SW,Imp",
+        "seats": {0: "fortune_teller", 1: "chef", 2: "empath", 3: "scarlet_woman", 4: "imp"},
+        "player_count": 5,
+        "known_discrepancy": "ZDD excludes FT from own pair choices; ASP allows self-pick",
+    },
+    # --- Fortune Teller + Poisoner ---
+    {
+        "name": "5p FT+Poisoner: FT,Chef,Empath,Poisoner,Imp",
+        "seats": {0: "fortune_teller", 1: "chef", 2: "empath", 3: "poisoner", 4: "imp"},
+        "player_count": 5,
+        "known_discrepancy": "Chef malfunctioning range + FT self-pick",
+    },
+    # --- Spy + Recluse ---
+    {
+        "name": "6p Spy+Recluse: WW,Chef,Spy,Recluse,SW,Imp",
+        "seats": {0: "washerwoman", 1: "chef", 2: "spy", 3: "recluse", 4: "scarlet_woman", 5: "imp"},
+        "player_count": 6,
+        "known_discrepancy": "ASP WW may_register_as_role includes non-townsfolk for Spy",
+    },
+    # --- Large: 7 players ---
+    {
+        "name": "7p all info: WW,Lib,Inv,Chef,Empath,SW,Imp",
+        "seats": {0: "washerwoman", 1: "librarian", 2: "investigator", 3: "chef", 4: "empath", 5: "scarlet_woman", 6: "imp"},
+        "player_count": 7,
+        "known_discrepancy": "ASP Librarian has no 'No Outsiders' path (UNSAT when no outsider registers)",
+    },
+    {
+        "name": "7p Spy+info: WW,Lib,Inv,Chef,Empath,Spy,Imp",
         "seats": {0: "washerwoman", 1: "librarian", 2: "investigator", 3: "chef", 4: "empath", 5: "spy", 6: "imp"},
         "player_count": 7,
+        "known_discrepancy": "ASP may_register_as_role includes cross-category roles for Spy",
     },
 ]
 
 
 # =============================================================================
-# Clingo Oracle — per-role choice counts
+# Clingo Oracle — count projected models
 # =============================================================================
 
-def is_info_role(role):
-    """Check if a role is a Night 1 info role."""
-    return role in {"washerwoman", "librarian", "investigator", "chef", "empath"}
+def load_asp_program():
+    """Load the ASP program files, stripping distribution constraints.
 
-
-def count_pair_role_choices(seats, player_count, info_seat, info_role, target_category,
-                            malfunctioning=False):
-    """Count valid choices for a pair-based info role (WW, Lib, Inv).
-
-    When functioning: target must actually have a role of the target category.
-    When malfunctioning: any pair of other players × any role of target category from script.
+    The ZDD Night Info phase operates on an already-validated seat assignment,
+    so we remove the integrity constraints that enforce correct role category
+    counts. This allows testing arbitrary seat assignments.
     """
-    if info_role == "washerwoman":
-        category_set = TOWNSFOLK
-        all_count = ALL_TOWNSFOLK_COUNT
-    elif info_role == "librarian":
-        category_set = OUTSIDERS
-        all_count = ALL_OUTSIDER_COUNT
-    elif info_role == "investigator":
-        category_set = MINIONS
-        all_count = ALL_MINION_COUNT
-    else:
-        return 0
+    program = ""
+    for f in ["botc.lp", "tb.lp", "players.lp"]:
+        program += open(ASP_ROOT / f).read() + "\n"
 
-    if malfunctioning:
-        # Any pair of other players × any role from the target category in the script
-        other_seats = [s for s in range(player_count) if s != info_seat]
-        n = len(other_seats)
-        pair_count = n * (n - 1) // 2
-        total = pair_count * all_count
-        # Librarian also gets "No Outsiders" as an option
-        if info_role == "librarian":
-            total += 1
-        return total
-
-    # Functioning: find actual targets
-    targets = []
-    for s, r in seats.items():
-        if s != info_seat and r in category_set:
-            targets.append((s, r))
-
-    if not targets:
-        if info_role == "librarian":
-            return 1  # "No Outsiders"
-        return 0
-
-    count = 0
-    for target_seat, target_role in targets:
-        for decoy in range(player_count):
-            if decoy != info_seat and decoy != target_seat:
-                count += 1
-    return count
+    # Remove distribution integrity constraints (lines like):
+    #   :- adjusted_townsfolk(N), #count { R : assigned(0, _, R), townsfolk(R) } != N.
+    #   :- adjusted_outsider(N), ...
+    #   :- adjusted_minion(N), ...
+    #   :- adjusted_demon(N), ...
+    import re
+    program = re.sub(
+        r'^:- adjusted_(townsfolk|outsider|minion|demon)\(N\),.*$',
+        '% [stripped for cross-validation]',
+        program,
+        flags=re.MULTILINE,
+    )
+    return program
 
 
-def count_chef_choices(seats, player_count, chef_seat, malfunctioning=False):
-    """Chef choices: 1 when functioning (determined), numPlayers+1 when malfunctioning."""
-    if malfunctioning:
-        return player_count + 1  # counts 0..numPlayers
-    return 1
+def make_scenario_program(base_program, scenario):
+    """Generate the full ASP program for a scenario."""
+    seats = scenario["seats"]
+    pc = scenario["player_count"]
+
+    lines = [base_program, f"#const player_count = {pc}.\n"]
+
+    for seat, role in sorted(seats.items()):
+        player = PLAYERS[seat]
+        lines.append(f"assigned(0, {player}, {role}).")
 
 
-def count_empath_choices(seats, player_count, empath_seat, malfunctioning=False):
-    """Empath choices: 1 when functioning (determined), 3 when malfunctioning."""
-    if malfunctioning:
-        return 3  # counts 0, 1, 2
-    return 1
+    # Projection atoms
+    lines.append("")
+    lines.append("% Derived projection atoms")
+    lines.append("poi_target(P) :- reminder_on(poi_poisoned, P, _).")
+    lines.append("ft_red_herring(P) :- reminder_on(ft_red_herring, P, _).")
+    lines.append("")
+    lines.append("#project st_tells_core/4.")
+    lines.append("#project poi_target/1.")
+    lines.append("#project ft_red_herring/1.")
+    lines.append("% FT pair choice is part of the observable state")
+    lines.append("#project player_chooses/4.")
+
+    return "\n".join(lines)
 
 
-def compute_role_choices(seats, player_count, malfunctioning_seats=None):
-    """Compute per-role choice counts, returning {role_name: count}.
+def count_asp_models(scenario, base_program):
+    """Count projected models for a scenario using clingo."""
+    program = make_scenario_program(base_program, scenario)
 
-    malfunctioning_seats: set of seats that are malfunctioning.
-    """
-    if malfunctioning_seats is None:
-        malfunctioning_seats = set()
+    ctl = clingo.Control(["0", "--project", "--warn=none"])
+    ctl.add("base", [], program)
+    ctl.ground([("base", [])])
 
-    per_role = {}
+    result = [0]
+    def on_model(model, r=result):
+        r[0] += 1
 
-    for seat, role in seats.items():
-        malf = seat in malfunctioning_seats
-
-        if role == "washerwoman":
-            c = count_pair_role_choices(seats, player_count, seat, role, TOWNSFOLK, malf)
-            if c > 0:
-                per_role["Washerwoman"] = c
-        elif role == "librarian":
-            c = count_pair_role_choices(seats, player_count, seat, role, OUTSIDERS, malf)
-            if c > 0:
-                per_role["Librarian"] = c
-        elif role == "investigator":
-            c = count_pair_role_choices(seats, player_count, seat, role, MINIONS, malf)
-            if c > 0:
-                per_role["Investigator"] = c
-        elif role == "chef":
-            c = count_chef_choices(seats, player_count, seat, malf)
-            if c > 0:
-                per_role["Chef"] = c
-        elif role == "empath":
-            c = count_empath_choices(seats, player_count, seat, malf)
-            if c > 0:
-                per_role["Empath"] = c
-
-    return per_role
-
-
-def asp_total_worlds(seats, player_count):
-    """Compute total night info worlds.
-
-    If Poisoner is in play: sum across branches (one per poisoner target).
-    Otherwise: simple product of per-role choices.
-    """
-    poisoner_seat = None
-    for s, r in seats.items():
-        if r == "poisoner":
-            poisoner_seat = s
-            break
-
-    if poisoner_seat is None:
-        # No Poisoner — simple cross-product
-        per_role = compute_role_choices(seats, player_count)
-        total = 1
-        for v in per_role.values():
-            total *= v
-        return total, per_role
-
-    # Poisoner in play — sum across branches
-    total = 0
-    # For the per-role summary, count how many valid outputs exist across ALL branches
-    combined_per_role = {}
-
-    for target in range(player_count):
-        if target == poisoner_seat:
-            continue
-
-        malfunctioning = {target}
-        branch_per_role = compute_role_choices(seats, player_count, malfunctioning)
-
-        branch_total = 1
-        for v in branch_per_role.values():
-            branch_total *= v
-        total += branch_total
-
-    # For per-role reporting, we report the number of outputs that are valid
-    # in at least one branch. This matches the ZDD's per-role counting
-    # (require each variable and check if count > 0 across the full ZDD).
-    # For a malfunctioning role, all outputs are valid; for functioning, only truthful.
-    # The union across all branches means: an output is valid if it's valid in ANY branch.
-    # For pair roles: functioning outputs + all malfunctioning outputs = all outputs
-    #   (since if the poisoner targets that role, ALL outputs are valid).
-    # For count roles: functioning output + all counts = all counts.
-    # So if an info role exists, the number of "reachable" outputs = malfunctioning count
-    #   (because the poisoner CAN target them, making all outputs reachable).
-    for seat, role in seats.items():
-        if not is_info_role(role):
-            continue
-        malf_choices = compute_role_choices(seats, player_count, {seat})
-        zdd_name = role.replace("_", " ").title()
-        if zdd_name in malf_choices:
-            combined_per_role[zdd_name] = malf_choices[zdd_name]
-
-    # Add Poisoner target count
-    combined_per_role["Poisoner"] = player_count - 1
-
-    return total, combined_per_role
+    ctl.solve(on_model=on_model)
+    return result[0]
 
 
 # =============================================================================
@@ -281,19 +222,8 @@ for (const [name, config] of Object.entries(scenarios)) {
     script: TROUBLE_BREWING,
   });
 
-  const perRole = {};
-  for (const [roleName, range] of result.roleVariableRanges) {
-    let validOutputs = 0;
-    for (let vid = range.start; vid < range.start + range.count; vid++) {
-      const constrained = zdd.require(result.root, vid);
-      if (zdd.count(constrained) > 0) validOutputs++;
-    }
-    perRole[roleName] = validOutputs;
-  }
-
   results[name] = {
     total: zdd.count(result.root),
-    perRole,
     variableCount: result.variableCount,
   };
 }
@@ -338,47 +268,67 @@ def run_zdd(scenarios):
 
 def compare():
     print("=" * 70)
-    print("Cross-validation: Night 1 Info — botc-asp (oracle) vs botc-zdd- (ZDD)")
+    print("Cross-validation: Night 1 Info")
+    print("  ASP oracle (clingo, projected) vs ZDD (botc-zdd-)")
     print("=" * 70)
 
-    zdd_results = run_zdd(SCENARIOS)
+    base_program = load_asp_program()
+
+    # Check if ZDD repo exists and is built
+    zdd_available = (ZDD_REPO / "dist" / "zdd.js").exists()
+    zdd_results = {}
+    if zdd_available:
+        print("\nRunning ZDD scenarios...")
+        zdd_results = run_zdd(SCENARIOS)
+    else:
+        print(f"\nWARNING: ZDD repo not found at {ZDD_REPO}")
+        print("Running ASP-only mode (no cross-validation)")
+
     all_pass = True
+    discrepancy_count = 0
 
     for sc in SCENARIOS:
         name = sc["name"]
         print(f"\n--- {name} ---")
-        seats_display = ", ".join(f"{s}={r}" for s, r in sorted(sc["seats"].items()))
+        seats_display = ", ".join(f"{s}={sc['seats'][s]}" for s in sorted(sc["seats"]))
         print(f"  Seats: {seats_display}")
 
-        asp_total, asp_per_role = asp_total_worlds(sc["seats"], sc["player_count"])
-        zdd = zdd_results[name]
-        zdd_total = zdd["total"]
-        zdd_per_role = zdd["perRole"]
+        asp_count = count_asp_models(sc, base_program)
+        print(f"  ASP count: {asp_count}")
 
-        total_match = asp_total == zdd_total
-        status = "PASS" if total_match else "FAIL"
-        print(f"  Total worlds:  ASP={asp_total:>6}  ZDD={zdd_total:>6}  [{status}]")
+        if zdd_available and name in zdd_results:
+            zdd_count = zdd_results[name]["total"]
+            match = asp_count == zdd_count
+            status = "PASS" if match else "FAIL"
+            print(f"  ZDD count: {zdd_count}")
+            print(f"  Match: [{status}]")
 
-        if not total_match:
-            all_pass = False
-
-        # Per-role comparison
-        all_role_names = sorted(set(list(asp_per_role.keys()) + list(zdd_per_role.keys())))
-        for role_name in all_role_names:
-            asp_val = asp_per_role.get(role_name, 0)
-            zdd_val = zdd_per_role.get(role_name, 0)
-            match = asp_val == zdd_val
-            rs = "PASS" if match else "FAIL"
-            print(f"    {role_name:>15}: ASP={asp_val:>4}  ZDD={zdd_val:>4}  [{rs}]")
             if not match:
-                all_pass = False
+                if "known_discrepancy" in sc:
+                    discrepancy_count += 1
+                    print(f"  Known discrepancy: {sc['known_discrepancy']}")
+                else:
+                    all_pass = False
+                    print(f"  ** UNEXPECTED MISMATCH **")
 
     print("\n" + "=" * 70)
     if all_pass:
-        print("ALL CHECKS PASSED")
+        if discrepancy_count > 0:
+            print(f"ALL CHECKS PASSED ({discrepancy_count} known discrepancies)")
+        else:
+            print("ALL CHECKS PASSED")
     else:
-        print("SOME CHECKS FAILED")
+        print("UNEXPECTED MISMATCHES FOUND — investigate!")
     print("=" * 70)
+
+    if discrepancy_count > 0:
+        print("\nKnown discrepancies to fix:")
+        print("  1. ZDD: Chef malfunctioning range is 0..N, should be 0..N/2")
+        print("  2. ASP: WW/Lib/Inv may_register_as_role allows cross-category")
+        print("     role names when Spy/Recluse is the reference player")
+        print("  3. ZDD: FT excludes self from pair choices; ASP allows self-pick")
+        print("  4. ASP: Librarian has no 'No Outsiders' info path")
+
     return all_pass
 
 

--- a/cross-validation/validate_night_info.py
+++ b/cross-validation/validate_night_info.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Cross-validate botc-zdd- Night 1 info role outputs against clingo oracle.
+
+For a fixed 5-player seat assignment, counts the number of valid ST
+information choices per info role and compares ZDD vs ASP results.
+
+Requirements:
+- Python clingo package: pip install clingo
+- botc-zdd- repo cloned and built: cd ../botc-zdd- && npx tsc
+"""
+
+import clingo
+import subprocess
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+ZDD_REPO = SCRIPT_DIR.parent.parent / "botc-zdd-"
+
+# =============================================================================
+# Test scenarios: (seat assignments, expected info)
+# =============================================================================
+
+SCENARIOS = [
+    {
+        "name": "5p: WW,Chef,Empath,Poisoner,Imp",
+        "seats": {0: "washerwoman", 1: "chef", 2: "empath", 3: "poisoner", 4: "imp"},
+        "player_count": 5,
+    },
+    {
+        "name": "5p: Poisoner,WW,Empath,Imp,Chef",
+        "seats": {0: "poisoner", 1: "washerwoman", 2: "empath", 3: "imp", 4: "chef"},
+        "player_count": 5,
+    },
+    {
+        "name": "5p: Investigator,Soldier,Virgin,Poisoner,Imp",
+        "seats": {0: "investigator", 1: "soldier", 2: "virgin", 3: "poisoner", 4: "imp"},
+        "player_count": 5,
+    },
+    {
+        "name": "6p: Librarian,Chef,Empath,Butler,Poisoner,Imp",
+        "seats": {0: "librarian", 1: "chef", 2: "empath", 3: "butler", 4: "poisoner", 5: "imp"},
+        "player_count": 6,
+    },
+    {
+        "name": "7p: WW,Lib,Inv,Chef,Empath,Poisoner,Imp",
+        "seats": {0: "washerwoman", 1: "librarian", 2: "investigator", 3: "chef", 4: "empath", 5: "poisoner", 6: "imp"},
+        "player_count": 7,
+    },
+]
+
+
+# =============================================================================
+# Clingo Oracle
+# =============================================================================
+
+def asp_role_name(name):
+    """Convert Python role name to ASP format."""
+    return name.lower().replace(" ", "_")
+
+
+def count_washerwoman_choices(seats, player_count):
+    """Count valid (playerA, playerB, townsfolk_role) triples for Washerwoman via ASP."""
+    # Find Washerwoman's seat
+    ww_seat = None
+    for s, r in seats.items():
+        if r == "washerwoman":
+            ww_seat = s
+            break
+    if ww_seat is None:
+        return 0
+
+    # Townsfolk roles (from BotC)
+    townsfolk = {"washerwoman", "librarian", "investigator", "chef", "empath",
+                 "fortune_teller", "undertaker", "monk", "ravenkeeper",
+                 "virgin", "slayer", "soldier", "mayor"}
+
+    # Find other townsfolk in play (not the WW herself)
+    targets = []
+    for s, r in seats.items():
+        if s != ww_seat and r in townsfolk:
+            targets.append((s, r))
+
+    # For each target, count valid decoys (any seat except WW and target)
+    count = 0
+    for target_seat, target_role in targets:
+        for decoy in range(player_count):
+            if decoy != ww_seat and decoy != target_seat:
+                count += 1
+    return count
+
+
+def count_librarian_choices(seats, player_count):
+    """Count valid Librarian info choices."""
+    lib_seat = None
+    for s, r in seats.items():
+        if r == "librarian":
+            lib_seat = s
+            break
+    if lib_seat is None:
+        return 0
+
+    outsiders = {"butler", "drunk", "recluse", "saint"}
+    targets = [(s, r) for s, r in seats.items() if s != lib_seat and r in outsiders]
+
+    if not targets:
+        return 1  # "No outsiders" is one valid output
+
+    count = 0
+    for target_seat, target_role in targets:
+        for decoy in range(player_count):
+            if decoy != lib_seat and decoy != target_seat:
+                count += 1
+    return count
+
+
+def count_investigator_choices(seats, player_count):
+    """Count valid Investigator info choices."""
+    inv_seat = None
+    for s, r in seats.items():
+        if r == "investigator":
+            inv_seat = s
+            break
+    if inv_seat is None:
+        return 0
+
+    minions = {"poisoner", "spy", "scarlet_woman", "baron"}
+    targets = [(s, r) for s, r in seats.items() if s != inv_seat and r in minions]
+
+    if not targets:
+        return 0
+
+    count = 0
+    for target_seat, target_role in targets:
+        for decoy in range(player_count):
+            if decoy != inv_seat and decoy != target_seat:
+                count += 1
+    return count
+
+
+def count_chef_choices(seats, player_count):
+    """Chef is fully determined — always 1 choice."""
+    chef_seat = None
+    for s, r in seats.items():
+        if r == "chef":
+            chef_seat = s
+            break
+    return 1 if chef_seat is not None else 0
+
+
+def count_empath_choices(seats, player_count):
+    """Empath is fully determined — always 1 choice."""
+    empath_seat = None
+    for s, r in seats.items():
+        if r == "empath":
+            empath_seat = s
+            break
+    return 1 if empath_seat is not None else 0
+
+
+def asp_total_worlds(seats, player_count):
+    """Compute total night info worlds as product of per-role choices."""
+    ww = count_washerwoman_choices(seats, player_count)
+    lib = count_librarian_choices(seats, player_count)
+    inv = count_investigator_choices(seats, player_count)
+    chef = count_chef_choices(seats, player_count)
+    empath = count_empath_choices(seats, player_count)
+
+    # Only multiply non-zero values (roles in play)
+    total = 1
+    per_role = {}
+    for name, val in [("Washerwoman", ww), ("Librarian", lib), ("Investigator", inv),
+                       ("Chef", chef), ("Empath", empath)]:
+        if val > 0:
+            total *= val
+            per_role[name] = val
+
+    return total, per_role
+
+
+# =============================================================================
+# ZDD Runner
+# =============================================================================
+
+ZDD_SCRIPT = """
+const { ZDD } = require('./dist/zdd.js');
+const { TROUBLE_BREWING } = require('./dist/botc.js');
+const { buildNightInfoZDD } = require('./dist/night.js');
+
+const scenarios = %SCENARIOS%;
+const results = {};
+
+for (const [name, config] of Object.entries(scenarios)) {
+  const seatRoles = new Map();
+  for (const [seat, role] of Object.entries(config.seats)) {
+    seatRoles.set(Number(seat), role);
+  }
+
+  const zdd = new ZDD();
+  const result = buildNightInfoZDD(zdd, {
+    numPlayers: config.player_count,
+    seatRoles,
+    selectedRoles: Object.values(config.seats),
+    script: TROUBLE_BREWING,
+  });
+
+  const perRole = {};
+  for (const [roleName, range] of result.roleVariableRanges) {
+    // Count worlds with this role's contribution
+    // For independent cross-product, the per-role choice count is
+    // the number of valid outputs (variables for exactly-one selection)
+    let validOutputs = 0;
+    for (let vid = range.start; vid < range.start + range.count; vid++) {
+      const constrained = zdd.require(result.root, vid);
+      if (zdd.count(constrained) > 0) validOutputs++;
+    }
+    perRole[roleName] = validOutputs;
+  }
+
+  results[name] = {
+    total: zdd.count(result.root),
+    perRole,
+    variableCount: result.variableCount,
+  };
+}
+
+console.log(JSON.stringify(results));
+"""
+
+
+def zdd_role_name(asp_name):
+    """Convert ASP role name to ZDD format."""
+    return asp_name.replace("_", " ").title()
+
+
+def run_zdd(scenarios):
+    """Run botc-zdd- night info builder for all scenarios."""
+    zdd_scenarios = {}
+    for sc in scenarios:
+        # Convert to ZDD role names
+        zdd_seats = {}
+        for seat, role in sc["seats"].items():
+            zdd_seats[str(seat)] = zdd_role_name(role)
+        zdd_scenarios[sc["name"]] = {
+            "seats": zdd_seats,
+            "player_count": sc["player_count"],
+        }
+
+    script = ZDD_SCRIPT.replace("%SCENARIOS%", json.dumps(zdd_scenarios))
+    result = subprocess.run(
+        ["node", "-e", script],
+        cwd=str(ZDD_REPO),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"ZDD error: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(result.stdout)
+
+
+# =============================================================================
+# Comparison
+# =============================================================================
+
+def compare():
+    print("=" * 70)
+    print("Cross-validation: Night 1 Info — botc-asp (oracle) vs botc-zdd- (ZDD)")
+    print("=" * 70)
+
+    zdd_results = run_zdd(SCENARIOS)
+    all_pass = True
+
+    for sc in SCENARIOS:
+        name = sc["name"]
+        print(f"\n--- {name} ---")
+        seats_display = ", ".join(f"{s}={r}" for s, r in sorted(sc["seats"].items()))
+        print(f"  Seats: {seats_display}")
+
+        asp_total, asp_per_role = asp_total_worlds(sc["seats"], sc["player_count"])
+        zdd = zdd_results[name]
+        zdd_total = zdd["total"]
+        zdd_per_role = zdd["perRole"]
+
+        total_match = asp_total == zdd_total
+        status = "PASS" if total_match else "FAIL"
+        print(f"  Total worlds:  ASP={asp_total:>6}  ZDD={zdd_total:>6}  [{status}]")
+
+        if not total_match:
+            all_pass = False
+
+        # Per-role comparison
+        all_roles = sorted(set(list(asp_per_role.keys()) + [zdd_role_name(k) for k in asp_per_role.keys()]))
+        for role_name in asp_per_role:
+            zdd_name = zdd_role_name(role_name) if role_name.islower() else role_name
+            asp_val = asp_per_role.get(role_name, 0)
+            zdd_val = zdd_per_role.get(zdd_name, 0)
+            match = asp_val == zdd_val
+            rs = "PASS" if match else "FAIL"
+            print(f"    {zdd_name:>15}: ASP={asp_val:>4}  ZDD={zdd_val:>4}  [{rs}]")
+            if not match:
+                all_pass = False
+
+    print("\n" + "=" * 70)
+    if all_pass:
+        print("ALL CHECKS PASSED")
+    else:
+        print("SOME CHECKS FAILED")
+    print("=" * 70)
+    return all_pass
+
+
+def main():
+    success = compare()
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/cross-validation/validate_night_info.py
+++ b/cross-validation/validate_night_info.py
@@ -2,8 +2,12 @@
 """
 Cross-validate botc-zdd- Night 1 info role outputs against clingo oracle.
 
-For a fixed 5-player seat assignment, counts the number of valid ST
-information choices per info role and compares ZDD vs ASP results.
+For a fixed seat assignment, counts the number of valid ST information
+choices per info role and compares ZDD vs ASP results.
+
+When the Poisoner is in play, the oracle computes per-branch world counts
+(one branch per poisoner target), where the targeted info role gets
+unconstrained outputs. The total world count is the sum across branches.
 
 Requirements:
 - Python clingo package: pip install clingo
@@ -20,7 +24,25 @@ SCRIPT_DIR = Path(__file__).parent
 ZDD_REPO = SCRIPT_DIR.parent.parent / "botc-zdd-"
 
 # =============================================================================
-# Test scenarios: (seat assignments, expected info)
+# Role categories (Trouble Brewing)
+# =============================================================================
+
+TOWNSFOLK = {"washerwoman", "librarian", "investigator", "chef", "empath",
+             "fortune_teller", "undertaker", "monk", "ravenkeeper",
+             "virgin", "slayer", "soldier", "mayor"}
+
+OUTSIDERS = {"butler", "drunk", "recluse", "saint"}
+
+MINIONS = {"poisoner", "spy", "scarlet_woman", "baron"}
+
+DEMONS = {"imp"}
+
+ALL_TOWNSFOLK_COUNT = len(TOWNSFOLK)  # 13
+ALL_OUTSIDER_COUNT = len(OUTSIDERS)   # 4
+ALL_MINION_COUNT = len(MINIONS)       # 4
+
+# =============================================================================
+# Test scenarios
 # =============================================================================
 
 SCENARIOS = [
@@ -49,135 +71,188 @@ SCENARIOS = [
         "seats": {0: "washerwoman", 1: "librarian", 2: "investigator", 3: "chef", 4: "empath", 5: "poisoner", 6: "imp"},
         "player_count": 7,
     },
+    # No-Poisoner scenarios (use Spy as the minion)
+    {
+        "name": "5p: WW,Chef,Empath,Spy,Imp (no Poisoner)",
+        "seats": {0: "washerwoman", 1: "chef", 2: "empath", 3: "spy", 4: "imp"},
+        "player_count": 5,
+    },
+    {
+        "name": "7p: WW,Lib,Inv,Chef,Empath,Spy,Imp (no Poisoner)",
+        "seats": {0: "washerwoman", 1: "librarian", 2: "investigator", 3: "chef", 4: "empath", 5: "spy", 6: "imp"},
+        "player_count": 7,
+    },
 ]
 
 
 # =============================================================================
-# Clingo Oracle
+# Clingo Oracle — per-role choice counts
 # =============================================================================
 
-def asp_role_name(name):
-    """Convert Python role name to ASP format."""
-    return name.lower().replace(" ", "_")
+def is_info_role(role):
+    """Check if a role is a Night 1 info role."""
+    return role in {"washerwoman", "librarian", "investigator", "chef", "empath"}
 
 
-def count_washerwoman_choices(seats, player_count):
-    """Count valid (playerA, playerB, townsfolk_role) triples for Washerwoman via ASP."""
-    # Find Washerwoman's seat
-    ww_seat = None
-    for s, r in seats.items():
-        if r == "washerwoman":
-            ww_seat = s
-            break
-    if ww_seat is None:
+def count_pair_role_choices(seats, player_count, info_seat, info_role, target_category,
+                            malfunctioning=False):
+    """Count valid choices for a pair-based info role (WW, Lib, Inv).
+
+    When functioning: target must actually have a role of the target category.
+    When malfunctioning: any pair of other players × any role of target category from script.
+    """
+    if info_role == "washerwoman":
+        category_set = TOWNSFOLK
+        all_count = ALL_TOWNSFOLK_COUNT
+    elif info_role == "librarian":
+        category_set = OUTSIDERS
+        all_count = ALL_OUTSIDER_COUNT
+    elif info_role == "investigator":
+        category_set = MINIONS
+        all_count = ALL_MINION_COUNT
+    else:
         return 0
 
-    # Townsfolk roles (from BotC)
-    townsfolk = {"washerwoman", "librarian", "investigator", "chef", "empath",
-                 "fortune_teller", "undertaker", "monk", "ravenkeeper",
-                 "virgin", "slayer", "soldier", "mayor"}
+    if malfunctioning:
+        # Any pair of other players × any role from the target category in the script
+        other_seats = [s for s in range(player_count) if s != info_seat]
+        n = len(other_seats)
+        pair_count = n * (n - 1) // 2
+        total = pair_count * all_count
+        # Librarian also gets "No Outsiders" as an option
+        if info_role == "librarian":
+            total += 1
+        return total
 
-    # Find other townsfolk in play (not the WW herself)
+    # Functioning: find actual targets
     targets = []
     for s, r in seats.items():
-        if s != ww_seat and r in townsfolk:
+        if s != info_seat and r in category_set:
             targets.append((s, r))
 
-    # For each target, count valid decoys (any seat except WW and target)
-    count = 0
-    for target_seat, target_role in targets:
-        for decoy in range(player_count):
-            if decoy != ww_seat and decoy != target_seat:
-                count += 1
-    return count
-
-
-def count_librarian_choices(seats, player_count):
-    """Count valid Librarian info choices."""
-    lib_seat = None
-    for s, r in seats.items():
-        if r == "librarian":
-            lib_seat = s
-            break
-    if lib_seat is None:
-        return 0
-
-    outsiders = {"butler", "drunk", "recluse", "saint"}
-    targets = [(s, r) for s, r in seats.items() if s != lib_seat and r in outsiders]
-
     if not targets:
-        return 1  # "No outsiders" is one valid output
-
-    count = 0
-    for target_seat, target_role in targets:
-        for decoy in range(player_count):
-            if decoy != lib_seat and decoy != target_seat:
-                count += 1
-    return count
-
-
-def count_investigator_choices(seats, player_count):
-    """Count valid Investigator info choices."""
-    inv_seat = None
-    for s, r in seats.items():
-        if r == "investigator":
-            inv_seat = s
-            break
-    if inv_seat is None:
-        return 0
-
-    minions = {"poisoner", "spy", "scarlet_woman", "baron"}
-    targets = [(s, r) for s, r in seats.items() if s != inv_seat and r in minions]
-
-    if not targets:
+        if info_role == "librarian":
+            return 1  # "No Outsiders"
         return 0
 
     count = 0
     for target_seat, target_role in targets:
         for decoy in range(player_count):
-            if decoy != inv_seat and decoy != target_seat:
+            if decoy != info_seat and decoy != target_seat:
                 count += 1
     return count
 
 
-def count_chef_choices(seats, player_count):
-    """Chef is fully determined — always 1 choice."""
-    chef_seat = None
-    for s, r in seats.items():
-        if r == "chef":
-            chef_seat = s
-            break
-    return 1 if chef_seat is not None else 0
+def count_chef_choices(seats, player_count, chef_seat, malfunctioning=False):
+    """Chef choices: 1 when functioning (determined), numPlayers+1 when malfunctioning."""
+    if malfunctioning:
+        return player_count + 1  # counts 0..numPlayers
+    return 1
 
 
-def count_empath_choices(seats, player_count):
-    """Empath is fully determined — always 1 choice."""
-    empath_seat = None
-    for s, r in seats.items():
-        if r == "empath":
-            empath_seat = s
-            break
-    return 1 if empath_seat is not None else 0
+def count_empath_choices(seats, player_count, empath_seat, malfunctioning=False):
+    """Empath choices: 1 when functioning (determined), 3 when malfunctioning."""
+    if malfunctioning:
+        return 3  # counts 0, 1, 2
+    return 1
+
+
+def compute_role_choices(seats, player_count, malfunctioning_seats=None):
+    """Compute per-role choice counts, returning {role_name: count}.
+
+    malfunctioning_seats: set of seats that are malfunctioning.
+    """
+    if malfunctioning_seats is None:
+        malfunctioning_seats = set()
+
+    per_role = {}
+
+    for seat, role in seats.items():
+        malf = seat in malfunctioning_seats
+
+        if role == "washerwoman":
+            c = count_pair_role_choices(seats, player_count, seat, role, TOWNSFOLK, malf)
+            if c > 0:
+                per_role["Washerwoman"] = c
+        elif role == "librarian":
+            c = count_pair_role_choices(seats, player_count, seat, role, OUTSIDERS, malf)
+            if c > 0:
+                per_role["Librarian"] = c
+        elif role == "investigator":
+            c = count_pair_role_choices(seats, player_count, seat, role, MINIONS, malf)
+            if c > 0:
+                per_role["Investigator"] = c
+        elif role == "chef":
+            c = count_chef_choices(seats, player_count, seat, malf)
+            if c > 0:
+                per_role["Chef"] = c
+        elif role == "empath":
+            c = count_empath_choices(seats, player_count, seat, malf)
+            if c > 0:
+                per_role["Empath"] = c
+
+    return per_role
 
 
 def asp_total_worlds(seats, player_count):
-    """Compute total night info worlds as product of per-role choices."""
-    ww = count_washerwoman_choices(seats, player_count)
-    lib = count_librarian_choices(seats, player_count)
-    inv = count_investigator_choices(seats, player_count)
-    chef = count_chef_choices(seats, player_count)
-    empath = count_empath_choices(seats, player_count)
+    """Compute total night info worlds.
 
-    # Only multiply non-zero values (roles in play)
-    total = 1
-    per_role = {}
-    for name, val in [("Washerwoman", ww), ("Librarian", lib), ("Investigator", inv),
-                       ("Chef", chef), ("Empath", empath)]:
-        if val > 0:
-            total *= val
-            per_role[name] = val
+    If Poisoner is in play: sum across branches (one per poisoner target).
+    Otherwise: simple product of per-role choices.
+    """
+    poisoner_seat = None
+    for s, r in seats.items():
+        if r == "poisoner":
+            poisoner_seat = s
+            break
 
-    return total, per_role
+    if poisoner_seat is None:
+        # No Poisoner — simple cross-product
+        per_role = compute_role_choices(seats, player_count)
+        total = 1
+        for v in per_role.values():
+            total *= v
+        return total, per_role
+
+    # Poisoner in play — sum across branches
+    total = 0
+    # For the per-role summary, count how many valid outputs exist across ALL branches
+    combined_per_role = {}
+
+    for target in range(player_count):
+        if target == poisoner_seat:
+            continue
+
+        malfunctioning = {target}
+        branch_per_role = compute_role_choices(seats, player_count, malfunctioning)
+
+        branch_total = 1
+        for v in branch_per_role.values():
+            branch_total *= v
+        total += branch_total
+
+    # For per-role reporting, we report the number of outputs that are valid
+    # in at least one branch. This matches the ZDD's per-role counting
+    # (require each variable and check if count > 0 across the full ZDD).
+    # For a malfunctioning role, all outputs are valid; for functioning, only truthful.
+    # The union across all branches means: an output is valid if it's valid in ANY branch.
+    # For pair roles: functioning outputs + all malfunctioning outputs = all outputs
+    #   (since if the poisoner targets that role, ALL outputs are valid).
+    # For count roles: functioning output + all counts = all counts.
+    # So if an info role exists, the number of "reachable" outputs = malfunctioning count
+    #   (because the poisoner CAN target them, making all outputs reachable).
+    for seat, role in seats.items():
+        if not is_info_role(role):
+            continue
+        malf_choices = compute_role_choices(seats, player_count, {seat})
+        zdd_name = role.replace("_", " ").title()
+        if zdd_name in malf_choices:
+            combined_per_role[zdd_name] = malf_choices[zdd_name]
+
+    # Add Poisoner target count
+    combined_per_role["Poisoner"] = player_count - 1
+
+    return total, combined_per_role
 
 
 # =============================================================================
@@ -208,9 +283,6 @@ for (const [name, config] of Object.entries(scenarios)) {
 
   const perRole = {};
   for (const [roleName, range] of result.roleVariableRanges) {
-    // Count worlds with this role's contribution
-    // For independent cross-product, the per-role choice count is
-    // the number of valid outputs (variables for exactly-one selection)
     let validOutputs = 0;
     for (let vid = range.start; vid < range.start + range.count; vid++) {
       const constrained = zdd.require(result.root, vid);
@@ -239,7 +311,6 @@ def run_zdd(scenarios):
     """Run botc-zdd- night info builder for all scenarios."""
     zdd_scenarios = {}
     for sc in scenarios:
-        # Convert to ZDD role names
         zdd_seats = {}
         for seat, role in sc["seats"].items():
             zdd_seats[str(seat)] = zdd_role_name(role)
@@ -292,14 +363,13 @@ def compare():
             all_pass = False
 
         # Per-role comparison
-        all_roles = sorted(set(list(asp_per_role.keys()) + [zdd_role_name(k) for k in asp_per_role.keys()]))
-        for role_name in asp_per_role:
-            zdd_name = zdd_role_name(role_name) if role_name.islower() else role_name
+        all_role_names = sorted(set(list(asp_per_role.keys()) + list(zdd_per_role.keys())))
+        for role_name in all_role_names:
             asp_val = asp_per_role.get(role_name, 0)
-            zdd_val = zdd_per_role.get(zdd_name, 0)
+            zdd_val = zdd_per_role.get(role_name, 0)
             match = asp_val == zdd_val
             rs = "PASS" if match else "FAIL"
-            print(f"    {zdd_name:>15}: ASP={asp_val:>4}  ZDD={zdd_val:>4}  [{rs}]")
+            print(f"    {role_name:>15}: ASP={asp_val:>4}  ZDD={zdd_val:>4}  [{rs}]")
             if not match:
                 all_pass = False
 

--- a/cross-validation/validate_night_info.py
+++ b/cross-validation/validate_night_info.py
@@ -14,10 +14,13 @@ the ZDD world count.
 - ft_red_herring/1: which player is the FT red herring (derived from ft_red_herring)
 
 **Known discrepancies** (documented, not bugs in the cross-validation):
-- ZDD treats Spy/Recluse registration independently per info role (each role
-  decides whether the Spy "registers as" its target type). The ASP models
-  registration as a single global ST choice that correlates across all info
-  roles. This causes the ZDD to overcount in multi-info-role + Spy scenarios.
+- ZDD Investigator: when Spy is the reference, findPairTargets offers all minion
+  role names (Baron, Poisoner, SW, Spy). But Spy lacks may_misregister_as(minion),
+  so the only valid name is "spy" (the true role). Overcounts by 4x.
+- ZDD Librarian: when the only outsider-registering player is the Spy, the ZDD
+  always treats Spy as an eligible reference. But Spy's outsider registration is
+  optional (a ST choice), so there should also be a "No Outsiders" branch for
+  when the Spy doesn't register as outsider. Undercounts by 1.
 
 Requirements:
 - Python clingo package: pip install clingo
@@ -109,7 +112,7 @@ SCENARIOS = [
         "name": "7p Spy+info: WW,Lib,Inv,Chef,Empath,Spy,Imp",
         "seats": {0: "washerwoman", 1: "librarian", 2: "investigator", 3: "chef", 4: "empath", 5: "spy", 6: "imp"},
         "player_count": 7,
-        "known_discrepancy": "ZDD treats Spy registration per-info-role independently; ASP correlates globally",
+        "known_discrepancy": "Two ZDD bugs: (1) Inv names any minion role for Spy, but Spy lacks may_misregister_as(minion) so only 'spy' is valid; (2) Lib missing 'No Outsiders' branch when Spy is the only outsider-registering player (registration is optional)",
     },
 ]
 
@@ -313,10 +316,11 @@ def compare():
     print("=" * 70)
 
     if discrepancy_count > 0:
-        print("\nKnown discrepancies to fix:")
-        print("  1. ZDD: Spy/Recluse registration is treated independently per info")
-        print("     role, but in the ASP (and in the real game) registration is a")
-        print("     single global ST choice that constrains all info roles together.")
+        print("\nKnown discrepancies to fix (both ZDD-side):")
+        print("  1. ZDD Inv: Spy as reference offers all minion role names, but Spy")
+        print("     lacks may_misregister_as(minion); only 'spy' is valid (4x overcount)")
+        print("  2. ZDD Lib: when Spy is the only outsider-registering player, Spy's")
+        print("     outsider registration is optional; missing 'No Outsiders' branch")
 
     return all_pass
 

--- a/cross-validation/validate_night_info.py
+++ b/cross-validation/validate_night_info.py
@@ -14,11 +14,10 @@ the ZDD world count.
 - ft_red_herring/1: which player is the FT red herring (derived from ft_red_herring)
 
 **Known discrepancies** (documented, not bugs in the cross-validation):
-- ASP Chef malfunctioning range is 0..player_count/2 (correct per game rules).
-  ZDD uses 0..numPlayers (too wide). ZDD bug, tracked separately.
-- ASP pair-based info roles (WW/Lib/Inv) allow naming ANY role the reference
-  player may_register_as, not just roles of the target type. E.g., WW can name
-  "Butler" when Spy is the reference. ASP bug, tracked separately.
+- ZDD treats Spy/Recluse registration independently per info role (each role
+  decides whether the Spy "registers as" its target type). The ASP models
+  registration as a single global ST choice that correlates across all info
+  roles. This causes the ZDD to overcount in multi-info-role + Spy scenarios.
 
 Requirements:
 - Python clingo package: pip install clingo
@@ -59,20 +58,17 @@ SCENARIOS = [
         "name": "5p Poisoner: WW,Chef,Empath,Poisoner,Imp",
         "seats": {0: "washerwoman", 1: "chef", 2: "empath", 3: "poisoner", 4: "imp"},
         "player_count": 5,
-        "known_discrepancy": "Chef malfunctioning range: ASP uses 0..N/2, ZDD uses 0..N",
     },
     {
         "name": "5p Poisoner rotated: Poisoner,WW,Empath,Imp,Chef",
         "seats": {0: "poisoner", 1: "washerwoman", 2: "empath", 3: "imp", 4: "chef"},
         "player_count": 5,
-        "known_discrepancy": "Chef malfunctioning range",
     },
     # --- Spy (no Poisoner) ---
     {
         "name": "5p Spy: WW,Chef,Empath,Spy,Imp",
         "seats": {0: "washerwoman", 1: "chef", 2: "empath", 3: "spy", 4: "imp"},
         "player_count": 5,
-        "known_discrepancy": "ASP WW may_register_as_role includes non-townsfolk for Spy",
     },
     # --- Recluse (no Poisoner) ---
     {
@@ -84,41 +80,36 @@ SCENARIOS = [
         "name": "5p Recluse+Inv: Investigator,Chef,Recluse,SW,Imp",
         "seats": {0: "investigator", 1: "chef", 2: "recluse", 3: "scarlet_woman", 4: "imp"},
         "player_count": 5,
-        "known_discrepancy": "ASP Inv may_register_as_role includes non-minion for Recluse",
     },
     # --- Fortune Teller (no Poisoner) ---
     {
         "name": "5p FT: FT,Chef,Empath,SW,Imp",
         "seats": {0: "fortune_teller", 1: "chef", 2: "empath", 3: "scarlet_woman", 4: "imp"},
         "player_count": 5,
-        "known_discrepancy": "ZDD excludes FT from own pair choices; ASP allows self-pick",
     },
     # --- Fortune Teller + Poisoner ---
     {
         "name": "5p FT+Poisoner: FT,Chef,Empath,Poisoner,Imp",
         "seats": {0: "fortune_teller", 1: "chef", 2: "empath", 3: "poisoner", 4: "imp"},
         "player_count": 5,
-        "known_discrepancy": "Chef malfunctioning range + FT self-pick",
     },
     # --- Spy + Recluse ---
     {
         "name": "6p Spy+Recluse: WW,Chef,Spy,Recluse,SW,Imp",
         "seats": {0: "washerwoman", 1: "chef", 2: "spy", 3: "recluse", 4: "scarlet_woman", 5: "imp"},
         "player_count": 6,
-        "known_discrepancy": "ASP WW may_register_as_role includes non-townsfolk for Spy",
     },
     # --- Large: 7 players ---
     {
         "name": "7p all info: WW,Lib,Inv,Chef,Empath,SW,Imp",
         "seats": {0: "washerwoman", 1: "librarian", 2: "investigator", 3: "chef", 4: "empath", 5: "scarlet_woman", 6: "imp"},
         "player_count": 7,
-        "known_discrepancy": "ASP Librarian has no 'No Outsiders' path (UNSAT when no outsider registers)",
     },
     {
         "name": "7p Spy+info: WW,Lib,Inv,Chef,Empath,Spy,Imp",
         "seats": {0: "washerwoman", 1: "librarian", 2: "investigator", 3: "chef", 4: "empath", 5: "spy", 6: "imp"},
         "player_count": 7,
-        "known_discrepancy": "ASP may_register_as_role includes cross-category roles for Spy",
+        "known_discrepancy": "ZDD treats Spy registration per-info-role independently; ASP correlates globally",
     },
 ]
 
@@ -323,11 +314,9 @@ def compare():
 
     if discrepancy_count > 0:
         print("\nKnown discrepancies to fix:")
-        print("  1. ZDD: Chef malfunctioning range is 0..N, should be 0..N/2")
-        print("  2. ASP: WW/Lib/Inv may_register_as_role allows cross-category")
-        print("     role names when Spy/Recluse is the reference player")
-        print("  3. ZDD: FT excludes self from pair choices; ASP allows self-pick")
-        print("  4. ASP: Librarian has no 'No Outsiders' info path")
+        print("  1. ZDD: Spy/Recluse registration is treated independently per info")
+        print("     role, but in the ASP (and in the real game) registration is a")
+        print("     single global ST choice that constrains all info roles together.")
 
     return all_pass
 

--- a/cross-validation/validate_night_info.py
+++ b/cross-validation/validate_night_info.py
@@ -13,15 +13,6 @@ the ZDD world count.
 - poi_target/1: which player the Poisoner targets (derived from poi_poisoned)
 - ft_red_herring/1: which player is the FT red herring (derived from ft_red_herring)
 
-**Known discrepancies** (documented, not bugs in the cross-validation):
-- ZDD Investigator: when Spy is the reference, findPairTargets offers all minion
-  role names (Baron, Poisoner, SW, Spy). But Spy lacks may_misregister_as(minion),
-  so the only valid name is "spy" (the true role). Overcounts by 4x.
-- ZDD Librarian: when the only outsider-registering player is the Spy, the ZDD
-  always treats Spy as an eligible reference. But Spy's outsider registration is
-  optional (a ST choice), so there should also be a "No Outsiders" branch for
-  when the Spy doesn't register as outsider. Undercounts by 1.
-
 Requirements:
 - Python clingo package: pip install clingo
 - botc-zdd- repo cloned and built: cd ../botc-zdd- && npx tsc
@@ -112,7 +103,6 @@ SCENARIOS = [
         "name": "7p Spy+info: WW,Lib,Inv,Chef,Empath,Spy,Imp",
         "seats": {0: "washerwoman", 1: "librarian", 2: "investigator", 3: "chef", 4: "empath", 5: "spy", 6: "imp"},
         "player_count": 7,
-        "known_discrepancy": "Two ZDD bugs: (1) Inv names any minion role for Spy, but Spy lacks may_misregister_as(minion) so only 'spy' is valid; (2) Lib missing 'No Outsiders' branch when Spy is the only outsider-registering player (registration is optional)",
     },
 ]
 
@@ -279,7 +269,6 @@ def compare():
         print("Running ASP-only mode (no cross-validation)")
 
     all_pass = True
-    discrepancy_count = 0
 
     for sc in SCENARIOS:
         name = sc["name"]
@@ -298,29 +287,15 @@ def compare():
             print(f"  Match: [{status}]")
 
             if not match:
-                if "known_discrepancy" in sc:
-                    discrepancy_count += 1
-                    print(f"  Known discrepancy: {sc['known_discrepancy']}")
-                else:
-                    all_pass = False
-                    print(f"  ** UNEXPECTED MISMATCH **")
+                all_pass = False
+                print(f"  ** UNEXPECTED MISMATCH **")
 
     print("\n" + "=" * 70)
     if all_pass:
-        if discrepancy_count > 0:
-            print(f"ALL CHECKS PASSED ({discrepancy_count} known discrepancies)")
-        else:
-            print("ALL CHECKS PASSED")
+        print("ALL CHECKS PASSED")
     else:
         print("UNEXPECTED MISMATCHES FOUND — investigate!")
     print("=" * 70)
-
-    if discrepancy_count > 0:
-        print("\nKnown discrepancies to fix (both ZDD-side):")
-        print("  1. ZDD Inv: Spy as reference offers all minion role names, but Spy")
-        print("     lacks may_misregister_as(minion); only 'spy' is valid (4x overcount)")
-        print("  2. ZDD Lib: when Spy is the only outsider-registering player, Spy's")
-        print("     outsider registration is optional; missing 'No Outsiders' branch")
 
     return all_pass
 

--- a/prompts/prompt3_spy_recluse_ft.md
+++ b/prompts/prompt3_spy_recluse_ft.md
@@ -1,0 +1,172 @@
+# Prompt 3: Spy/Recluse registration + Fortune Teller red herring
+
+PR #5 established Poisoner target selection and malfunctioning info roles. Now add Spy/Recluse mis-registration effects on existing info roles, and add the Fortune Teller as a new info role with its red herring mechanic.
+
+## Spy registration
+
+The Spy is a Minion but can **register as** Townsfolk, Outsider, or Minion (NOT Demon) to info roles. The Spy can also register as Good or Evil for alignment-checking roles (Chef, Empath). Critically, the Spy can register DIFFERENTLY to each info role because they act at different times in the night order. Registration is a Storyteller choice, not a player choice.
+
+### Effect on pair info roles (Washerwoman, Librarian, Investigator)
+
+When functioning, the current code finds valid "reference targets" by checking `getRoleType(role, script) === targetType`. The Spy changes this: the Spy's seat is a valid reference target for roles checking Townsfolk (Washerwoman), Outsider (Librarian), AND Minion (Investigator).
+
+Furthermore, when the Spy is the reference target, the ST can name **any role of the registering category from the script** — not just the Spy's actual role. This is because `may_register_as_role` for the Spy includes all roles of categories the Spy can register as.
+
+Concretely:
+- **Washerwoman**: Spy can be the reference. Valid outputs: `(spy_seat, decoy) × ALL 13 Townsfolk roles`. For a normal Townsfolk target like the Chef at seat 1, valid outputs are only `(1, decoy) × {"Chef"}`.
+- **Librarian**: Spy can be the reference. Valid outputs: `(spy_seat, decoy) × ALL 4 Outsider roles`.
+- **Investigator**: Spy is already a Minion, but the expansion still applies — the ST can name any Minion role, not just "Spy". So instead of `(spy_seat, decoy) × {"Spy"}`, it becomes `(spy_seat, decoy) × ALL 4 Minion roles`.
+
+Note: the Spy can also be a **decoy** (the non-reference player in the shown pair). This is already handled — any non-info-role, non-reference seat can be a decoy. Nothing changes for decoys.
+
+### Effect on Chef
+
+The Chef counts adjacent evil pairs using alignment registration. The Spy can register as Evil or Good at Chef's time. This means the Chef's count is no longer fully determined by the seat assignment — it depends on the ST's registration choice for the Spy.
+
+Compute all possible evil pair counts by considering the Spy registering as evil vs. good. The valid Chef outputs are the set of all achievable counts. For example, if the Spy is adjacent to the Imp:
+- Spy registers evil → evil pair count includes (Spy, Imp)
+- Spy registers good → that pair doesn't count
+- So Chef has 2 valid counts instead of 1
+
+### Effect on Empath
+
+Same principle. If the Spy is a living neighbor of the Empath, the Spy can register as Evil or Good, changing the Empath's count. Compute all achievable counts and allow any of them.
+
+## Recluse registration
+
+The Recluse is an Outsider but can register as Outsider, Minion, or Demon (NOT Townsfolk). Can register as Good or Evil.
+
+### Effect on pair info roles
+
+- **Washerwoman**: Recluse CANNOT register as Townsfolk → no effect.
+- **Librarian**: Recluse is already an Outsider, so it's already a valid target. But when the Recluse is the reference, the ST can name ANY Outsider role (not just "Recluse"). So Recluse expands Librarian outputs from `(recluse_seat, decoy) × {"Recluse"}` to `(recluse_seat, decoy) × ALL 4 Outsider roles`.
+- **Investigator**: Recluse can register as Minion, so the Recluse becomes a valid reference target. Valid outputs: `(recluse_seat, decoy) × ALL 4 Minion roles`. This means a good player can appear as a minion to the Investigator.
+
+### Effect on Chef and Empath
+
+Same as Spy: Recluse can register as Evil, so compute all achievable evil pair counts / evil neighbor counts considering Recluse evil vs. good.
+
+### Combined Spy + Recluse
+
+When both Spy and Recluse are in play, their registration choices are independent. For Chef/Empath, enumerate all combinations (Spy evil/good × Recluse evil/good) and collect all achievable counts.
+
+## Fortune Teller
+
+The Fortune Teller is a new Night 1 info role (also acts on other nights, but that's Prompt 4's concern). The FT chooses two players each night and the ST tells them "Yes" or "No" — whether one of the chosen players is the Demon.
+
+### Red herring setup
+
+At game setup (before Night 1), the ST designates exactly one player as the Fortune Teller's "red herring." Constraints on the red herring:
+- Cannot be the actual Demon (by role assignment, not registration)
+- Must be a player who CAN register as Good (note: this is about eligibility, not a forced registration)
+
+The red herring always pings as "the Demon" to the Fortune Teller, even though they aren't.
+
+### Red herring variables
+
+Add red herring designation variables to the Night 1 phase, analogous to poisoner target variables. One variable per eligible player. exactlyOne constraint. The eligible players are: everyone except the Demon seat and the FT seat.
+
+Why exclude the FT seat? The FT can't choose themselves as one of the two players they ask about (the rules say the FT points at two other players), and the red herring only matters for FT queries, so placing it on the FT itself would have no gameplay effect. Actually — check whether the ASP rules allow the red herring on the FT. If they do, include the FT seat as eligible. The constraint is just: not the Demon.
+
+(On reflection: the ASP rule is `not demon(R)` for the red herring player, and the red herring must register as good. The FT is a Townsfolk, so they always register as good. The ASP rules don't exclude the FT. So include the FT seat as eligible.)
+
+Correction: eligible red herring seats = all seats except the Demon seat. (N-1 candidates.)
+
+### FT output variables
+
+For each possible pair of players the FT could choose (C(N-1, 2) pairs, excluding the FT from both positions), and for each answer (Yes/No), create a variable. The valid answers when functioning depend on:
+
+- A chosen player "pings" if they register as Demon OR carry the red herring token
+- If either chosen player pings → answer is Yes
+- If neither pings → answer is No
+
+When malfunctioning (poisoned/drunk), any (pair, answer) is valid.
+
+### Branching for red herring
+
+The FT outputs DEPEND on which player is the red herring, similar to how info outputs depend on which seat the Poisoner targets. For each possible red herring designation, the set of valid FT outputs changes (which pairs give "Yes" vs "No").
+
+However, the red herring does NOT affect non-FT info roles (WW, Lib, Inv, Chef, Empath are unaffected). So the branching can be structured as:
+
+1. Non-FT info roles: build once, independent of red herring
+2. FT outputs: branch per red herring candidate, union the FT ZDDs
+3. Red herring designation variable: one per branch (like poisoner target)
+4. Cross-product: (non-FT info ZDD) × (union of red-herring × FT-output branches)
+
+This layers on top of the existing Poisoner branching. The full branch structure when both Poisoner and FT are in play:
+
+For each poisoner target:
+  - Non-FT info roles with poisoner malfunctioning effect
+  - If FT is poisoned (target == FT seat): FT unconstrained, red herring exactlyOne (doesn't constrain FT)
+  - If FT is not poisoned: for each red herring candidate, build constrained FT outputs, union
+  - Combine via product (non-FT × FT+redherring) then union across poisoner branches
+
+### Variable ordering
+
+Variable IDs should be ordered: poisoner targets (if any), red herring designation, FT outputs, then other info role outputs. Or: poisoner targets, other info role outputs, red herring designation, FT outputs. The key constraint is that variables within a dependent group are contiguous. Choose whichever ordering makes the implementation cleanest.
+
+### New types
+
+Add a `RedHerringOutput` type (analogous to `PoisonerTargetOutput`) with a `targetSeat` field. Add `redHerringOutputs: Map<number, RedHerringOutput>` to `NightInfoResult`. Add `findRedHerringVariable(result, targetSeat)` lookup helper.
+
+Add FT to the pair/count info output types — the FT output is a (playerA, playerB, answer) triple, which could use a new `FortuneTellerOutput` type with `playerA`, `playerB`, `answer: "Yes" | "No"` fields, plus a lookup helper `findFortuneTellerVariable(result, playerA, playerB, answer)`.
+
+## Role metadata changes
+
+The `Role` interface needs a way to express registration capabilities. Add an optional `registersAs` field to `Role`:
+
+```typescript
+export interface Role {
+  name: string;
+  type: RoleType;
+  distributionModifier?: DistributionModifier;
+  /** Categories this role can register as (Spy, Recluse). If absent, registers only as actual type. */
+  registersAs?: {
+    roleTypes: RoleType[];  // e.g., Spy: [Townsfolk, Outsider, Minion]
+    alignments: ("Good" | "Evil")[];  // e.g., Spy: ["Good", "Evil"]
+  };
+}
+```
+
+Update `TROUBLE_BREWING` to add this for Spy and Recluse:
+- Spy: `registersAs: { roleTypes: [Townsfolk, Outsider, Minion], alignments: ["Good", "Evil"] }`
+- Recluse: `registersAs: { roleTypes: [Outsider, Minion, Demon], alignments: ["Good", "Evil"] }`
+
+The night info builder uses this metadata to determine: (a) which seats are valid reference targets for pair roles, (b) which role names can be shown for each reference target, and (c) what registration choices affect Chef/Empath counts.
+
+## Testing
+
+### Spy tests
+- Spy in play, no Poisoner: WW valid outputs expand (Spy as Townsfolk reference with all 13 Townsfolk role names)
+- Spy in play: Librarian outputs expand (Spy as Outsider reference with all 4 Outsider role names)
+- Spy in play: Investigator outputs expand (Spy can be named as any Minion, not just "Spy")
+- Spy adjacent to evil: Chef has 2 valid counts (Spy evil vs. good)
+- Spy as Empath neighbor: Empath has 2 valid counts
+- Spy + Poisoner: total world count = sum of per-branch counts with expanded outputs
+
+### Recluse tests
+- Recluse in play: Investigator sees Recluse as valid Minion reference
+- Recluse in play: Librarian outputs expand (Recluse can be named as any Outsider)
+- Recluse adjacent to evil: Chef count expands
+- Recluse as Empath neighbor: Empath count expands
+
+### Fortune Teller tests
+- FT in play, no Poisoner: red herring variables present, FT output variables present
+- FT with specific red herring: require red herring on seat X, verify FT outputs constrained
+- FT with Demon in pair: always "Yes" regardless of red herring
+- FT with red herring in pair: "Yes" regardless of actual demon
+- FT with neither Demon nor red herring: "No"
+- FT malfunctioning (poisoned): any pair+answer valid
+- FT red herring + Poisoner: branching structure works
+
+### Combined tests
+- Spy + Recluse + FT + Poisoner: verify total world count
+- Cross-validate total world counts against the Python oracle (I will update validate_night_info.py after this merges)
+
+## What NOT to do
+
+- Do not model the Undertaker (it's a "later night" role that requires day/execution, beyond Prompt 3's scope)
+- Do not model other-night FT queries (Prompt 4)
+- Do not add death or day phase mechanics
+- Do not change distribution or seat assignment code
+- Do not model Spy "seeing the Grimoire" ability (that's a different mechanic from registration)


### PR DESCRIPTION
Compares clingo oracle (ground truth from ASP rules) against the
botc-zdd- library's distribution ZDD builder. Reveals two bugs in
the ZDD library:

1. buildDistributionZDD includes Baron in the minion pool without
   requiring Baron's outsider adjustment, producing invalid
   distributions where Baron is selected but counts aren't modified.

2. buildDistributionZDDWithBaron hardcodes +2/-2 outsider/townsfolk
   modifier for all player counts, but for player_count < 7, the
   Baron modifier should be +1/-1 (per ASP: causes_outsider_mod(baron, 1)
   when player_count < 7).

Files:
- cross-validation/count_distributions.lp: Minimal distribution-only ASP
- cross-validation/count_distrib.py: Standalone oracle count generator
- cross-validation/validate_distributions.py: Full cross-validation script

https://claude.ai/code/session_01FFgnzzQMMenY7AjE64Gtpb